### PR TITLE
JBDS-2757 Remove java 6 requirement of EAP from installer

### DIFF
--- a/installer/src/config/resources/CustomLangpack_eng.xml
+++ b/installer/src/config/resources/CustomLangpack_eng.xml
@@ -5,8 +5,7 @@
     <str id="PathInputPanel.fileDialog.title" txt="Select Target Folder"/>
     <str id="JREPathPanel.fileDialog.title" txt="Select Java VM Home Folder"/>
     <str id="JREPathPanel.headline.jre" txt="Select Java VM"/>
-	<str id="JREPathPanel.intro" txt="JBoss Developer Studio works with Java 6 and has been tested with OpenJDK, Oracle and Apple JDK."/>
-	<str id="JREPathPanel.java6.warning" txt="Please note that JBoss EAP 6 requires Java 6 or higher." />
+	<str id="JREPathPanel.intro" txt="JBoss Developer Studio works with Java 6 and Java 7 and has been tested with OpenJDK, Oracle and Apple JDK."/>
 	<str id="JREPathPanel.dataModel.title" txt="Installation type:" />
 	<str id="JREPathPanel.dataModel32.title" txt="32-bit" />
 	<str id="JREPathPanel.dataModel64.title" txt="64-bit" />
@@ -29,9 +28,9 @@
     <str id="installer.of" txt="of"/>
     <str id="installer.cannotInstallOver" txt="You can't upgrade by installing over the top"/>
     <str id="UpdatePacksPanel.summaryCaption" txt="Following components will be installed:"/>
-    <str id="JBossAsSelectPanel.question" txt="Developer Studio includes JBoss Enterprise Application Platform. Would you like to install it?"/>
+    <str id="JBossAsSelectPanel.question" txt="Developer Studio includes Red Hat JBoss Enterprise Application Platform. Would you like to install it?"/>
     <str id="JBossAsSelectPanel.question1" txt="Add Locations you want to be scanned to discover Platforms and Servers you have"/>
-    <str id="JBossAsSelectPanel.YesOption" txt="Yes, and have it ready for use in Developer Studio (Java 6 is required to run JBoss EAP 6)"/>
+    <str id="JBossAsSelectPanel.YesOption" txt="Yes, and have it ready for use in Developer Studio"/>
     <str id="JBossAsSelectPanel.NoOption" txt="No"/>
     <str id="JBossAsSelectPanel.FindButton" txt="Find..."/>
     <str id="JBossAsSelectPanel.AddButton" txt="Add..."/>

--- a/installer/src/panels/com/jboss/jbds/installer/JREPathPanel.java
+++ b/installer/src/panels/com/jboss/jbds/installer/JREPathPanel.java
@@ -92,8 +92,6 @@ public class JREPathPanel extends PathInputPanel implements IChangeListener
         String introText = getI18nStringForClass("intro", "PathInputPanel");
         
         add(new JLabel(introText), NEXT_LINE);
-        introText = getI18nStringForClass("java6.warning", "PathInputPanel");
-        add(new JLabel(introText), NEXT_LINE);
         
         
         rb1 = new JRadioButton("Default Java VM", true);


### PR DESCRIPTION
I think this was added when we still supported running of JBDS with Java 5,
but now that JBDS needs Java 6 I think it's not needed to point this out explicitly.
Also, JBoss EAP is changed to Red Hat JBoss EAP in one instance.
