### PR TITLE
[JBDS-2797] .ini upgrade issue for 7.0.1 OSX users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 workspace
 jbds-echoproperties.txt
 target*/
+bin

--- a/installer/src/config/install-pack-universal.xml
+++ b/installer/src/config/install-pack-universal.xml
@@ -38,13 +38,6 @@
       </description>
     </pack>
 
-    <pack name="JBoss Developer Studio @{specification.version.presentstring} Metadata Generation" id="jbds.plist" installGroups="jbosseap,jbds" required="no">
-      <description>
-        JBoss Developer Studio @{specification.version.presentstring} Mac OSX Package Properties Update
-      </description>
-      <singlefile src="config/resources/JBoss Developer Studio.app/Contents/Info.plist" target="$INSTALL_PATH/studio/jbdevstudio.app/Contents/Info.plist" override="true" os="mac" />
-    </pack>
-
     <pack name="JBoss Enterprise Application Platform" id="jbosseap" installGroups="jbosseap" required="no">
       <description>
         JBoss Enterprise Application Platform

--- a/installer/src/config/resources/readme.txt
+++ b/installer/src/config/resources/readme.txt
@@ -14,7 +14,7 @@ On Linux that would be:
 cd <install-path>
 ./jbdevstudio
 
-For OS X the application is as <install-path>/JBoss Developer Studio.app
+For OS X the application is as <install-path>/jbdevstudio.app
 
 For Windows use <install-path>/jbdevstudio.bat
 

--- a/installer/src/panels/com/izforge/izpack/panels/SimpleFinishPanel.java
+++ b/installer/src/panels/com/izforge/izpack/panels/SimpleFinishPanel.java
@@ -177,7 +177,7 @@ public class SimpleFinishPanel extends IzPanel {
 				command = new String[3];
 				command[0] = "open";
 				command[1] = "-a";
-				command[2] = path+File.separator+"JBoss Developer Studio.app";
+				command[2] = path+File.separator+"jbdevstudio.app";
 			}else{
 				command = new String[]{path+File.separator+"jbdevstudio"};
 				if(OsVersion.IS_WINDOWS){

--- a/installer/src/panels/com/jboss/jbds/installer/CreateLinkPanel.java
+++ b/installer/src/panels/com/jboss/jbds/installer/CreateLinkPanel.java
@@ -52,9 +52,6 @@ public class CreateLinkPanel extends IzPanel {
 		File install = new File(idata.getVariable("INSTALL_PATH"));
 		File studio = new File(install , "studio");
 		File app = new File(studio,"jbdevstudio.app");
-		if(app.exists()) {
-			app.renameTo(new File(studio,"JBoss Developer Studio.app"));
-		}
 		createSoftLink();
 		writeProperty("runtime_locations.properties");
 		addJREPath();
@@ -71,16 +68,8 @@ public class CreateLinkPanel extends IzPanel {
 		if(isUnixLikeSystem()) {
 
 			StringBuffer cmd = new StringBuffer();
-			String launcherLocation = installPath+File.separator+"studio";
-			String launcherName = "jbdevstudio";
-			if(OsVersion.IS_OSX) {
-				File oldLauncher = new File(launcherLocation,"JBoss Developer Studio.app");
-				if(oldLauncher.exists()) {
-					 launcherName = "JBoss Developer Studio.app";
-				} else {
-					launcherName = "jbdevstudio.app";
-				}
-			} 
+			String launcherName = OsVersion.IS_OSX ? "jbdevstudio.app" : "jbdevstudio";
+			 
 			cmd.append("cd \"").append(installPath).append("\"\n")
 				.append("ln -s \"." + File.separator + "studio" + File.separator)
 				.append(launcherName + "\"")
@@ -148,7 +137,7 @@ public class CreateLinkPanel extends IzPanel {
 			FileOutputStream stream = new FileOutputStream(file);
 			stream.write(str.getBytes());
 			stream.close();
-		} catch (Exception ex) {
+		} catch (IOException ex) {
 			ex.printStackTrace();
 		}
 	}
@@ -164,34 +153,16 @@ public class CreateLinkPanel extends IzPanel {
 	}
 
 	public static void addJREPath(String installPath, String execPath) {
-		File pathOld = new File(installPath + File.separator + "eclipse" + File.separator
-				+ "eclipse.ini");
-		File pathNew1 = new File(installPath + File.separator + "studio" + File.separator
+		File pathLinuxWindows = new File(installPath + File.separator + "studio" + File.separator
 				+ "jbdevstudio.ini");
-		File pathNew2 = new File(installPath + File.separator + "studio" + File.separator  
-				+ "JBoss Developer Studio.app" + File.separator + "Contents" + File.separator +"MacOS" + File.separator
-				+ "JBoss Developer Studio.ini");
-		File pathNew3 = new File(installPath + File.separator + "studio" + File.separator  
+		File pathMacosx = new File(installPath + File.separator + "studio" + File.separator  
 				+ "jbdevstudio.app" + File.separator + "Contents" + File.separator +"MacOS" + File.separator
 				+ "jbdevstudio.ini");
-		File pathNew4 = new File(installPath + File.separator + "studio" + File.separator  
-				+ "JBoss Developer Studio.app" + File.separator + "Contents" + File.separator +"MacOS" + File.separator
-				+ "jbdevstudio.ini");
-		if(pathOld.exists() ) {
-			addJVM(execPath, pathOld);
-		} else if(pathNew1.exists()) {
-			addJVM(execPath, pathNew1);
-		} else if(pathNew2.exists()) {
-			addJVM(execPath, pathNew2);
-			if(pathNew3.exists()) {
-				addJVM(execPath, pathNew3);
-			}
-		} else if(pathNew3.exists()) {
-			addJVM(execPath, pathNew3);
-		} else if(pathNew4.exists()) {
-			addJVM(execPath, pathNew4);
+		if(pathLinuxWindows.exists()) {
+			addJVM(execPath, pathLinuxWindows);
+		} else if(pathMacosx.exists()) {
+			addJVM(execPath, pathMacosx);
 		} 
-		
 	}
 
 	public static void addJVM(String execPath, File path) {

--- a/site/com.jboss.jbds.product
+++ b/site/com.jboss.jbds.product
@@ -19,22 +19,7 @@ Red Hat, Inc. - Initial implementation.
 
    <configIni use="default">
    </configIni>
-<!--
-   Defaults set in Eclipse Kepler JEE, Java, Classic, and Platform Runtime Binary* (as of 4.3M6):
-      launcher.XXMaxPermSize=256m
-      launcher.defaultAction=openFile
-      XX:MaxPermSize=256m
-      Xms40m
-      Xmx512m
 
-   * - Platform Runtime Binary sets a lower max mem limit of Xmx384m
-
-   If launcher.XXMaxPermSize=256m is not set, I get tons of 'java.lang.OutOfMemoryError: PermGen space' errors on launch, especially if I've updated JBDS installer w/ stuff from Central. So while this is already set in Eclipse SDK/PRB/JEE Bundles, it's NOT set in the installer unless we specify it here. Better to see it in jbdevstudio.ini twice than not at all. ~nickboldt
-
-   launcher.defaultAction=openFile gets dropped when building installer; used to associate Eclipse executable w/ File > Open as default action. http://help.eclipse.org/juno/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fmisc%2Fruntime-options.html
-
-   Be sure to remove anything added there via com.jboss.jbds.p2.inf file when uninstalling the product, or you will leave Eclipse in an unusable state (JBDS-2389).
--->
    <launcherArgs>
       <programArgs>-product
 com.jboss.jbds.product.product
@@ -48,7 +33,7 @@ openFile</programArgs>
 -Xmx1024m
 -Dosgi.instance.area.default=@user.home/workspace</vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
--Xdock:icon=../Resources/JBDevStudio.icns -XX:MaxPermSize=256m</vmArgsMac>
+-Xdock:icon=../Resources/JBDevStudio.icns -XX:MaxPermSize=256m -Xdock:name=&quot;JBoss Developer Studio&quot;</vmArgsMac>
    </launcherArgs>
 
    <windowImages/>


### PR DESCRIPTION
This commit contains fixes for:
1. readme.txt content
   Launcher name for Mac OS X was updated to jbdevstudio.app
2. .plist update during installation
   This update is  not required anymore, because .ini for Mac defined
   in .product file updated to have
   -Xdock:name="JBoss Developer Studio"
   to control global menu app name, doc name stays as jbdevstudio
3. SimpleFinishPanel updated to launch jbdevstudio.app
4. CreateLinkPanel creates jbdevstudio.app soft link to app in studio folder
5. CreateLinkPanel adds -vm only to jbdevstudio.ini inside installation folder
   or
   inside mas osx jbdevstudio.app package
6. .gitignore file updated to ingnore bin folders
