### PR TITLE
[JBDS-2879] org.eclipse.core.net bundle is not included in p2director

### DIFF
--- a/p2-director/com.jboss.jbds.p2.director/META-INF/MANIFEST.MF
+++ b/p2-director/com.jboss.jbds.p2.director/META-INF/MANIFEST.MF
@@ -12,5 +12,6 @@ Require-Bundle: org.eclipse.equinox.p2.director.app;bundle-version="1.0.300",
  org.eclipse.equinox.p2.director;bundle-version="2.1.0",
  org.eclipse.equinox.p2.engine;bundle-version="2.1.0",
  org.eclipse.equinox.p2.metadata;bundle-version="2.1.0",
- org.eclipse.equinox.p2.repository;bundle-version="2.1.0"
+ org.eclipse.equinox.p2.repository;bundle-version="2.1.0",
+ org.eclipse.core.net;bundle-version="1.2.200"
 Export-Package: com.jboss.jbds.internal.p2.director


### PR DESCRIPTION
added missing plugin to manifest
