### PR TITLE
[JBDS-3068] Installer fails to recognize java versions without underscore

### DIFF
--- a/installer/src/panels/com/jboss/devstudio/core/installer/JREPathPanel.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/JREPathPanel.java
@@ -394,7 +394,7 @@ public class JREPathPanel extends PathInputPanel implements IChangeListener
 			return -5;
 		}
 		
-        if(! detectedVersion.matches("1\\.[1-9]\\.[0-9][_\\-].*")) {
+        if(!detectedVersion.matches("1\\.[1-9]\\.[0-9].*")) {
         	return -4; // Unknown version
         }
         int versionNumber = Integer.parseInt(detectedVersion.substring(2,3)); 


### PR DESCRIPTION
remove [_\-] to make it optional
