### PR TITLE
Classpath has not included all required library references

### DIFF
--- a/installer/.classpath
+++ b/installer/.classpath
@@ -5,6 +5,9 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/3"/>
 	<classpathentry kind="var" path="IZPACK_HOME/lib/installer.jar" sourcepath="/IZPACK_HOME/src/lib"/>
-	<classpathentry kind="var" path="IZPACK_HOME/lib/uninstaller.jar"/>
+	<classpathentry kind="var" path="IZPACK_HOME/lib/uninstaller.jar" sourcepath="/IZPACK_HOME/src/lib"/>
+	<classpathentry kind="var" path="IZPACK_HOME/bin/panels/HTMLHelloPanel.jar" sourcepath="/IZPACK_HOME/src/lib"/>
+	<classpathentry kind="var" path="IZPACK_HOME/bin/panels/ShortcutPanel.jar" sourcepath="/IZPACK_HOME/src/lib"/>
+	<classpathentry kind="var" path="IZPACK_HOME/bin/panels/InstallationGroupPanel.jar" sourcepath="/IZPACK_HOME/src/lib"/>
 	<classpathentry kind="output" path="build/eclipse"/>
 </classpath>


### PR DESCRIPTION
Fix adds references to required libraries referenced through eclipse path
variable IZPACK_HOME.
