### PR TITLE
[JBDS-3363] Remove Portlet tooling from default JBDS installation

### DIFF
--- a/features/com.jboss.devstudio.core.feature/feature.xml
+++ b/features/com.jboss.devstudio.core.feature/feature.xml
@@ -25,7 +25,6 @@
   <includes id="org.jboss.tools.cdi.deltaspike.feature" version="0.0.0"/>
   <includes id="org.jboss.tools.project.examples.feature" version="0.0.0"/> 
   <includes id="org.jboss.tools.ws.feature" version="0.0.0"/> 
-  <includes id="org.jboss.tools.portlet.feature" version="0.0.0"/> 
   <includes id="org.jboss.tools.central.feature" version="0.0.0"/> 
   <includes id="org.jboss.tools.forge.feature" version="0.0.0"/> 
   <includes id="org.jboss.tools.vpe.browsersim.feature" version="0.0.0"/> 

--- a/site/category.xml
+++ b/site/category.xml
@@ -134,10 +134,6 @@
     <category name="CoreTools" />
     <category name="WebTools" />
   </feature>
-  <feature id="org.jboss.tools.portlet.feature">
-    <category name="CoreTools" />
-    <category name="WebTools" />
-  </feature>
   <feature id="org.jboss.tools.forge.feature">
     <category name="CoreTools"/>
     <category name="WebTools" />


### PR DESCRIPTION
Rortlet is removed from:
- JBDS Core feature
- JBDS Update Site
