### PR TITLE
[JBDS-3182] Installer step 4: remove obsolete 'bit' radio buttons

### DIFF
--- a/installer/src/panels/com/izforge/izpack/installer/Unpacker.java
+++ b/installer/src/panels/com/izforge/izpack/installer/Unpacker.java
@@ -179,7 +179,6 @@ public class Unpacker extends UnpackerBase
 							"director" + File.separator +
 							"plugins" + File.separator);
 					File[] launchers = pluginsFolder.listFiles(new FilenameFilter() {
-						@Override
 						public boolean accept(File dir, String name) {
 							return name.startsWith("org.eclipse.equinox.launcher") && name.endsWith(".jar");
 						}
@@ -232,7 +231,6 @@ public class Unpacker extends UnpackerBase
 	    							"studio" + File.separator +
 	    							"plugins" + File.separator);
 	    					File[] studioLaunchers = studioPluginsFolder.listFiles(new FilenameFilter() {
-	    						@Override
 	    						public boolean accept(File dir, String name) {
 	    							return name.startsWith("org.eclipse.equinox.launcher") && name.endsWith(".jar");
 	    						}

--- a/installer/src/panels/com/izforge/izpack/panels/SimpleFinishPanel.java
+++ b/installer/src/panels/com/izforge/izpack/panels/SimpleFinishPanel.java
@@ -108,7 +108,6 @@ public class SimpleFinishPanel extends IzPanel {
 
 			final JCheckBox runAfterCheckbox = new JCheckBox(parent.langpack.getString("SimpleFinishPanel.headline.run_after"), true);
 			runAfterCheckbox.addItemListener(new ItemListener() {
-				@Override
 				public void itemStateChanged(ItemEvent e) {
 					SimpleFinishPanel.this.runAfterAction.setRunAfter(runAfterCheckbox.isSelected());
 				}

--- a/installer/src/panels/com/jboss/devstudio/core/installer/ErrorUtils.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/ErrorUtils.java
@@ -43,7 +43,6 @@ public class ErrorUtils {
 			
 			JButton ok = new JButton("OK");
 			ok.addActionListener(new ActionListener(){
-				@Override
 				public void actionPerformed(ActionEvent arg0) {
 					frame.dispose();
 				}

--- a/installer/src/panels/com/jboss/devstudio/core/installer/InstallAdditionalFeaturesPanelAutomationHelper.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/InstallAdditionalFeaturesPanelAutomationHelper.java
@@ -19,7 +19,6 @@ public class InstallAdditionalFeaturesPanelAutomationHelper implements PanelAuto
 	public static final String LOCATIONS_NODE_NAME = "locations";
 	public static final String IUS_NODE_NAME = "ius";
 
-	@Override
 	public void makeXMLData(AutomatedInstallData installData, IXMLElement panelRoot) {
 		IXMLElement ius = new XMLElementImpl(IUS_NODE_NAME,panelRoot);
 		IXMLElement locations = new XMLElementImpl(LOCATIONS_NODE_NAME,panelRoot);
@@ -29,7 +28,6 @@ public class InstallAdditionalFeaturesPanelAutomationHelper implements PanelAuto
 		panelRoot.addChild(locations);
 	}
 
-	@Override
 	public void runAutomated(AutomatedInstallData idata, IXMLElement panelRoot) throws InstallerException {
 		IXMLElement ius = panelRoot.getFirstChildNamed(IUS_NODE_NAME);
 		IXMLElement locations = panelRoot.getFirstChildNamed(LOCATIONS_NODE_NAME);

--- a/installer/src/panels/com/jboss/devstudio/core/installer/JREPathPanel.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/JREPathPanel.java
@@ -6,6 +6,7 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
+import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
@@ -130,45 +131,59 @@ public class JREPathPanel extends PathInputPanel implements IChangeListener {
 
 		pathSelectionPanel.addChangeListener(this);
 		
-		JPanel jvmInfo = new JPanel();
-		Border border2 = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder((EtchedBorder.LOWERED)), "JVM Information");
+		JPanel jvmInfo = new JPanel() {
+			@Override
+			public int getWidth() {
+				return pathSelectionPanel.getWidth();
+			}
+		};
+		Border border2 = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder((EtchedBorder.LOWERED)), "VM Information");
 		jvmInfo.setBorder(border2);
 		jvmInfo.setLayout(new GridBagLayout());
 		
 		GridBagConstraints c = new GridBagConstraints();
 		c.gridx = 0;
 		c.gridy = 0;
-		
+		c.insets = new Insets(4,4,2,4);
+		c.weightx = 0;
 		c.anchor = GridBagConstraints.LINE_START;
 		jvmInfo.add(new JLabel("Vendor:",LEFT),c);
 		
 		c = new GridBagConstraints();
 		c.gridx = 0;
 		c.gridy = 1;
+		c.insets = new Insets(2,4,2,4);
+		c.weightx = 0;
 		c.anchor = GridBagConstraints.LINE_START;		
 		jvmInfo.add(new JLabel("Version:",LEFT),c);
 
 		c = new GridBagConstraints();
 		c.gridx = 0;
 		c.gridy = 2;
+		c.insets = new Insets(2,4,4,4);
+		c.weightx = 0;
 		c.anchor = GridBagConstraints.LINE_START;
 		jvmInfo.add(new JLabel("Architecture:",LEFT),c);
 
 		c = new GridBagConstraints();
 		c.gridx = 1;
 		c.gridy = 0;
+		c.insets = new Insets(4,2,2,4);
+		c.weightx = 1;
 		c.fill = GridBagConstraints.HORIZONTAL;
 		jvmInfo.add(vendor = new JLabel(""),c);
 		
 		c = new GridBagConstraints();
 		c.gridx = 1;
 		c.gridy = 1;
+		c.insets = new Insets(2,2,2,4);
 		c.fill = GridBagConstraints.HORIZONTAL;
 		jvmInfo.add(version = new JLabel(""),c);
 
 		c = new GridBagConstraints();
 		c.gridx = 1;
 		c.gridy = 2;
+		c.insets = new Insets(2,2,4,4);
 		c.fill = GridBagConstraints.HORIZONTAL;
 		jvmInfo.add(arch = new JLabel(""),c);
 		
@@ -276,9 +291,9 @@ public class JREPathPanel extends PathInputPanel implements IChangeListener {
 		Properties properties = new Properties();
 		int status = verifyVersion(pathSelectionPanel.getPath(),properties);
 		if("installer".equals(idata.getVariable("PACK_NAME"))) {
-			vendor.setText(properties.getProperty(SYSPN_JAVA_VENDOR));
-			version.setText(properties.getProperty(SYSPN_JAVA_VERSION));
-			arch.setText(properties.getProperty(SYSPN_SUN_ARCH_DATA_MODEL));
+			vendor.setText(properties.getProperty(SYSPN_JAVA_VENDOR,"Unknown"));
+			version.setText(properties.getProperty(SYSPN_JAVA_VERSION,"Unknown"));
+			arch.setText(properties.getProperty(SYSPN_SUN_ARCH_DATA_MODEL) == null ? "Unknown" : properties.getProperty(SYSPN_SUN_ARCH_DATA_MODEL) +"-bit");
 			arch.getParent().doLayout();
 		}
 		return status;

--- a/installer/src/panels/com/jboss/devstudio/core/installer/P2IUListPanel.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/P2IUListPanel.java
@@ -125,7 +125,6 @@ public class P2IUListPanel extends JPanel {
 		SelectAllAction() {
 			super("Select All");
 		}
-		@Override
 		public void actionPerformed(ActionEvent e) {
 			selectAll();
 		}
@@ -136,7 +135,6 @@ public class P2IUListPanel extends JPanel {
 		DeselectAllAction() {
 			super("Deselect All");
 		}
-		@Override
 		public void actionPerformed(ActionEvent e) {
 			deselectAll();
 		}

--- a/installer/src/panels/com/jboss/devstudio/core/installer/PathSelectionPanel.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/PathSelectionPanel.java
@@ -93,17 +93,14 @@ public class PathSelectionPanel extends JPanel implements ActionListener, Layout
         textField.addActionListener(this);
         textField.getDocument().addDocumentListener(new DocumentListener(){
 
-			@Override
 			public void changedUpdate(DocumentEvent arg0) {
 				fireChange();
 			}
 
-			@Override
 			public void insertUpdate(DocumentEvent arg0) {
 				fireChange();
 			}
 
-			@Override
 			public void removeUpdate(DocumentEvent arg0) {
 				fireChange();
 			}

--- a/installer/src/panels/com/jboss/devstudio/core/installer/RunAfterAction.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/RunAfterAction.java
@@ -17,7 +17,6 @@ public class RunAfterAction implements com.izforge.izpack.util.CleanupClient {
 		this.installData = installData;
 	}
 
-	@Override
     public void cleanUp() {
     	if (this.runAfter && this.installData.installSuccess) {
     		this.panel.runAfter();

--- a/installer/src/panels/com/jboss/devstudio/core/installer/ServerListPanel.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/ServerListPanel.java
@@ -187,15 +187,12 @@ public class ServerListPanel extends JPanel {
 			protected TableColumnModel createDefaultColumnModel() {
 				TableColumnModel model = super.createDefaultColumnModel();
 				model.addColumnModelListener(new TableColumnModelListener() {
-					@Override
 					public void columnAdded(TableColumnModelEvent e) {
 					}
 
-					@Override
 					public void columnRemoved(TableColumnModelEvent e) {
 					}
 
-					@Override
 					public void columnMoved(TableColumnModelEvent e) {
 						if (!ignoreUpdates) {
 							ignoreUpdates = true;
@@ -203,7 +200,6 @@ public class ServerListPanel extends JPanel {
 						}
 					}
 
-					@Override
 					public void columnMarginChanged(ChangeEvent e) {
 						if (!ignoreUpdates) {
 							ignoreUpdates = true;
@@ -211,7 +207,6 @@ public class ServerListPanel extends JPanel {
 						}
 					}
 
-					@Override
 					public void columnSelectionChanged(ListSelectionEvent e) {
 					}
 				});


### PR DESCRIPTION
Fix removes radio buttons and add VM Information group to show vendor, version and architecture for selested VM.
It also remove @Overrides annotation to be compilable under JDK 1.5
