### PR TITLE
JBDS-3411 initial fix to have p2 do proper build

### DIFF
--- a/site/pom.xml
+++ b/site/pom.xml
@@ -49,7 +49,10 @@
 				<configuration>
 					<products>
 						<product>
-							<id>com.jboss.devstudio.core.package</id>
+						  <id>com.jboss.devstudio.core.package</id>
+						  <rootFolders>
+						    <macosx>jbdevstudio.app</macosx>
+						  </rootFolders>
 						</product>
 					</products>
 				</configuration>


### PR DESCRIPTION
For this PR to work, still need to manually override Tycho version to 0.23.0-SNAPSHOT, eg., `mvn install -DtychoVersion=0.23.0-SNAPSHOT`