### PR TITLE
JBDS-3411 have installer build actually use M6 p2 product build

### DIFF
--- a/installer/src/panels/com/izforge/izpack/installer/Unpacker.java
+++ b/installer/src/panels/com/izforge/izpack/installer/Unpacker.java
@@ -54,6 +54,7 @@ import com.izforge.izpack.util.FileExecutor;
 import com.izforge.izpack.util.Housekeeper;
 import com.izforge.izpack.util.IoHelper;
 import com.izforge.izpack.util.OsConstraint;
+import com.izforge.izpack.util.OsVersion;
 import com.jboss.devstudio.core.installer.ConsoleCommandException;
 import com.jboss.devstudio.core.installer.ErrorUtils;
 import com.jboss.devstudio.core.installer.P2DirectorStarterListener;
@@ -228,7 +229,7 @@ public class Unpacker extends UnpackerBase
 	                	handler.nextStep(pack.name, i + 1, 1);
 	                	try {
 	                		File studioPluginsFolder = new File(installLocation + File.separator +
-	    							"studio" + File.separator +
+	                				P2DirectorStarterListener.JBDEVSTUDIO_LOCATION + File.separator +
 	    							"plugins" + File.separator);
 	    					File[] studioLaunchers = studioPluginsFolder.listFiles(new FilenameFilter() {
 	    						public boolean accept(File dir, String name) {

--- a/installer/src/panels/com/jboss/devstudio/core/installer/CreateLinkPanel.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/CreateLinkPanel.java
@@ -13,6 +13,7 @@ import com.izforge.izpack.installer.InstallData;
 import com.izforge.izpack.installer.InstallerFrame;
 import com.izforge.izpack.installer.IzPanel;
 import com.izforge.izpack.installer.PanelAutomation;
+import com.izforge.izpack.util.Debug;
 import com.izforge.izpack.util.OsVersion;
 import com.izforge.izpack.util.os.unix.ShellScript;
 
@@ -23,6 +24,7 @@ public class CreateLinkPanel extends IzPanel {
 			"jre" + File.separator + "bin" + File.separator + "javaw.exe" };
 	private static final String linTestFiles[] = new String[] { "bin" + File.separator + "java",
 		"jre" + File.separator + "bin" + File.separator + "java" };
+	private String installPath = "";
 
 	public CreateLinkPanel(InstallerFrame parent, InstallData idata) {
 		super(parent, idata);
@@ -49,9 +51,7 @@ public class CreateLinkPanel extends IzPanel {
 	}
 
 	public void panelActivate() {
-		File install = new File(idata.getVariable("INSTALL_PATH"));
-		File studio = new File(install , "studio");
-		File app = new File(studio,"jbdevstudio.app");
+		installPath = idata.getVariable("INSTALL_PATH");
 		createSoftLink();
 		writeProperty("runtime_locations.properties");
 		addJREPath();
@@ -91,9 +91,8 @@ public class CreateLinkPanel extends IzPanel {
 	}
 	
 	public void writeProperty(String fileName) {
-		String installPath = idata.getVariable("INSTALL_PATH");
 
-		File folder = new File(installPath, "studio");
+		File folder = new File(installPath, P2DirectorStarterListener.JBDEVSTUDIO_LOCATION);
 
 		Properties servers = (Properties) idata.getAttribute("AS_SERVERS");
 		if (!servers.isEmpty()) {
@@ -109,21 +108,21 @@ public class CreateLinkPanel extends IzPanel {
 				stream.flush();
 				stream.close();
 			} catch (IOException e) {
+				e.printStackTrace();
+			} finally {
 				if (stream != null) {
 					try {
 						stream.close();
 					} catch (IOException e1) {
+						Debug.trace(e1);
 					}
 				}
-				e.printStackTrace();
 			}
 		}
 	}
 
 	public void createLink(String fileName, String folderName) {
-		String installPath = idata.getVariable("INSTALL_PATH");
-		String path;
-		path = installPath + File.separator + "eclipse" + File.separator
+		String path = installPath + File.separator + "eclipse" + File.separator
 				+ "links";
 
 		File folder = new File(path);
@@ -155,8 +154,7 @@ public class CreateLinkPanel extends IzPanel {
 	public static void addJREPath(String installPath, String execPath) {
 		File pathLinuxWindows = new File(installPath + File.separator + "studio" + File.separator
 				+ "jbdevstudio.ini");
-		File pathMacosx = new File(installPath + File.separator + "studio" + File.separator  
-				+ "jbdevstudio.app" + File.separator + "Contents" + File.separator +"MacOS" + File.separator
+		File pathMacosx = new File(installPath + File.separator + "studio" + File.separator + P2DirectorStarterListener.JBDEVSTUDIO_LOCATION + File.separator
 				+ "jbdevstudio.ini");
 		if(pathLinuxWindows.exists()) {
 			addJVM(execPath, pathLinuxWindows);
@@ -180,7 +178,7 @@ public class CreateLinkPanel extends IzPanel {
 				try {
 					is.close();
 				} catch (IOException e) {
-					e.printStackTrace();
+					Debug.trace(e);  
 				}
 			}
 		}
@@ -198,7 +196,7 @@ public class CreateLinkPanel extends IzPanel {
 				try {
 					stream.close();
 				} catch (IOException e) {
-					e.printStackTrace();
+					Debug.trace(e);
 				}
 			}
 		}

--- a/installer/src/panels/com/jboss/devstudio/core/installer/P2DirectorStarterListener.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/P2DirectorStarterListener.java
@@ -21,6 +21,8 @@ import com.jboss.devstudio.core.installer.JavaVersionReader.ResponseListener;
 
 public class P2DirectorStarterListener implements InstallerListener {
 
+	public static final String JBDEVSTUDIO_LOCATION =  "studio" + (OsVersion.IS_OSX ? File.separator + "jbdevstudio.app" + File.separator + "Contents" + File.separator + "Eclipse" : "");
+	
 	private String installLocation;
 	private String selectedJvm;
 	
@@ -124,7 +126,7 @@ public class P2DirectorStarterListener implements InstallerListener {
 		}
 		
 		public void close() {
-			File studioLocation = new File(parameters.get(3),"studio");
+			File studioLocation = new File(parameters.get(3), JBDEVSTUDIO_LOCATION);
 			File cancelLocation = new File(studioLocation, "cancel");
 			Debug.trace(cancelLocation);
 			try {
@@ -146,7 +148,7 @@ public class P2DirectorStarterListener implements InstallerListener {
 		
 		private List<String> bundles = new ArrayList<String>(256);
 		public BundleListConsoleCommand() {
-			cmd="-jar \"{1}\" -l -r " + URL_SURROUND_CHAR + "{2}" + URL_SURROUND_CHAR + " -d \"{3}/studio\"";
+			cmd="-jar \"{1}\" -l -r " + URL_SURROUND_CHAR + "{2}" + URL_SURROUND_CHAR + " -d \"{3}" + File.separator + JBDEVSTUDIO_LOCATION + "\" ";
 		}
 
 		@Override
@@ -175,7 +177,7 @@ public class P2DirectorStarterListener implements InstallerListener {
 					"-vm \"{0}\" " +
 					"-r " +
 					URL_SURROUND_CHAR + "{2}" + URL_SURROUND_CHAR + " " +
-					"-d \"{3}" + File.separator + "studio\" " +
+					"-d \"{3}" + File.separator + JBDEVSTUDIO_LOCATION + "\" " +
 					"-p jbds " +
 					"-i {4} " +
 					"-profileProperties org.eclipse.update.install.features=true";

--- a/installer/src/panels/com/jboss/devstudio/core/installer/ShortcutPanelPatch.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/ShortcutPanelPatch.java
@@ -19,22 +19,23 @@ public class ShortcutPanelPatch extends IzPanel {
 	 * Should we also keep runtimes/ folder? If so will need a way to REMOVE files in uninstallData as it currently only supports add()
 	 */
 	protected String[] additionalUninstallableFiles = {
+		
 		/* files/folders in studio folder */
-		"studio" + System.getProperty("file.separator") + "readme",
-		"studio" + System.getProperty("file.separator") + "features",
-		"studio" + System.getProperty("file.separator") + "plugins",
-		"studio" + System.getProperty("file.separator") + "p2",
-		"studio" + System.getProperty("file.separator") + "artifacts.xml",
-		"studio" + System.getProperty("file.separator") + ".eclipseproduct",
-		"studio" + System.getProperty("file.separator") + "epl-v10.html",
-		"studio" + System.getProperty("file.separator") + "icon.xpm",
-		"studio" + System.getProperty("file.separator") + "jbdevstudio",
-		"studio" + System.getProperty("file.separator") + "notice.html",
-		"studio" + System.getProperty("file.separator") + "runtime_locations.properties",
-		"studio" + System.getProperty("file.separator") + "48-jbds_icon.png",
-		"studio" + System.getProperty("file.separator") + "48-jbds_uninstall_icon.png",
-		"studio" + System.getProperty("file.separator") + "jbds.ico",
-		"studio" + System.getProperty("file.separator") + "jbds_uninstall.ico",
+		"studio" + File.separator + "readme",
+		P2DirectorStarterListener.JBDEVSTUDIO_LOCATION + File.separator + "features",
+		P2DirectorStarterListener.JBDEVSTUDIO_LOCATION + File.separator + "plugins",
+		P2DirectorStarterListener.JBDEVSTUDIO_LOCATION + File.separator + "p2",
+		P2DirectorStarterListener.JBDEVSTUDIO_LOCATION + File.separator + "artifacts.xml",
+		P2DirectorStarterListener.JBDEVSTUDIO_LOCATION + File.separator + ".eclipseproduct",
+		P2DirectorStarterListener.JBDEVSTUDIO_LOCATION + File.separator + "epl-v10.html",
+		P2DirectorStarterListener.JBDEVSTUDIO_LOCATION + File.separator + "icon.xpm",
+		P2DirectorStarterListener.JBDEVSTUDIO_LOCATION + File.separator + "jbdevstudio",
+		P2DirectorStarterListener.JBDEVSTUDIO_LOCATION + File.separator + "notice.html",
+		P2DirectorStarterListener.JBDEVSTUDIO_LOCATION + File.separator + "runtime_locations.properties",
+		"studio" + File.separator + "48-jbds_icon.png",
+		"studio" + File.separator + "48-jbds_uninstall_icon.png",
+		"studio" + File.separator + "jbds.ico",
+		"studio" + File.separator + "jbds_uninstall.ico",
 
 		/* files/folders in root folder */
 		"Uninstaller",

--- a/plugins/com.jboss.devstudio.core.central/pom.xml
+++ b/plugins/com.jboss.devstudio.core.central/pom.xml
@@ -10,7 +10,11 @@
 	<groupId>com.jboss.devstudio.core.plugins</groupId>
 	<artifactId>com.jboss.devstudio.core.central</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	
+
+	<properties>
+		<noVpn>false</noVpn>
+	</properties>
+
 	<build>
 		<resources>
 			<resource>
@@ -48,7 +52,7 @@
               <goal>wget</goal>
             </goals>
             <configuration>
-              <skip>false</skip>
+              <skip>${noVpn}</skip>
               <url>http://www.qa.jboss.com/binaries/RHDS/discovery/nightly/core/${jbosstools_site_stream}/devstudio-earlyaccess.properties</url>
               <overwrite>true</overwrite>
               <skipCache>true</skipCache>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <eapRootFolder>jboss-eap-6.1</eapRootFolder>
     <buildEAPBundle>false</buildEAPBundle>
     <devstudio.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${BUILD_ALIAS}</devstudio.version>
+    <tychoVersion>0.23.0-SNAPSHOT</tychoVersion>
   </properties>
 
   <build>
@@ -188,6 +189,10 @@
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
+    </pluginRepository>
+    <pluginRepository>
+      <id>tycho-snapshots</id>
+      <url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
     </pluginRepository>
   </pluginRepositories>
 </project>

--- a/site/com.jboss.devstudio.core.p2.inf
+++ b/site/com.jboss.devstudio.core.p2.inf
@@ -13,6 +13,13 @@ units.1.requires.1.name=com.jboss.devstudio.core.package
 units.1.requires.1.range=[$version$,$version$]
 units.1.requires.1.greedy=true
 
+requires.0.namespace=org.eclipse.equinox.p2.iu
+requires.0.name=a.jre.javase
+requires.0.range=[1.7.0,1.7.0]
+requires.1.namespace=org.eclipse.equinox.p2.iu
+requires.1.name=config.a.jre.javase
+requires.1.range=[1.7.0,1.7.0]
+
 instructions.unconfigure=\
 org.eclipse.equinox.p2.touchpoint.eclipse.removeProgramArg(programArg:-product);\
 org.eclipse.equinox.p2.touchpoint.eclipse.removeProgramArg(programArg:com.jboss.devstudio.core.product);\

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -51,6 +51,9 @@
 						<product>
 							<id>com.jboss.devstudio.core.package</id>
 						</product>
+						<rootFolders>
+							<macosx>jbdevstudio.app</macosx>
+						</rootFolders>
 					</products>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
Fix changes destination folder on mac to ${install-target-dir}/studio/jbdevstudo.app
That forces Mars M6 p2.director to materialize jbdevstudio inside jbdevstudio.app.
Benefites are:
1. jbdevstudio.app location doesn't change
2. jbdevstudio.ini is not ignored anymore
