### PR TITLE
[JBDS-3390] Create test to verify offline installation

### DIFF
--- a/installer/build.xml
+++ b/installer/build.xml
@@ -356,6 +356,24 @@ $Id: build.xml,v 1.1.2.14 2006/03/31 07:47:31 starksm Exp $
     </izpack>
 
     <checksum file="${destination.dir}/${installer.name}.jar" />
+	
+  	<if>
+  		<not>
+  			<isset property="skipTests" />
+  		</not>
+  		<then>
+			<loadfile srcfile="${basedir}/jbdevstudio-test-install.xml" property="jbdevstudio-test-install.xml.updated">
+				<filterchain>
+					<expandproperties/>
+				</filterchain>
+			</loadfile>
+			<echo file="${project.build.directory}/jbdevstudio-test-install.xml">${jbdevstudio-test-install.xml.updated}</echo>
+		
+			<java jar="${destination.dir}/${installer.name}.jar" fork="true" failonerror="true" maxmemory="512m" jvmargs="-DTRACE=true -Djava.security.manager -Djava.security.policy=${basedir}/java.policy">
+				<arg line="${project.build.directory}/jbdevstudio-test-install.xml"/>
+			</java>
+  		</then>
+  	</if>
   </target>
 
   <target name="clean">

--- a/installer/java.policy
+++ b/installer/java.policy
@@ -1,0 +1,17 @@
+/* AUTOMATICALLY GENERATED ON Thu Apr 30 22:27:42 PDT 2015*/
+/* DO NOT EDIT */
+
+grant {
+  permission java.lang.RuntimePermission "getenv.izpack.mode";
+  permission java.io.FilePermission "<<ALL FILES>>", "read,write,execute,delete";
+  permission java.util.PropertyPermission "*", "read,write";
+  permission java.lang.RuntimePermission "*";
+  permission org.osgi.framework.AdminPermission "*";
+  permission org.osgi.framework.ServicePermission "*", "register,get";
+  permission java.net.NetPermission "*";
+  permission org.osgi.framework.AdaptPermission "*", "adapt";
+  permission org.eclipse.equinox.log.LogPermission "*", "log";
+  permission java.lang.reflect.ReflectPermission "*";
+  permission org.osgi.service.application.ApplicationAdminPermission "*", "lifecycle";
+};
+

--- a/installer/jbdevstudio-test-install.xml
+++ b/installer/jbdevstudio-test-install.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<AutomatedInstallation langpack="eng">
+<com.jboss.devstudio.core.installer.HTMLInfoPanelWithRootWarning id="introduction"/>
+<com.izforge.izpack.panels.HTMLLicencePanel id="licence"/>
+<com.jboss.devstudio.core.installer.PathInputPanel id="target">
+<installpath>${project.build.directory}/jbdevstudio-install-test</installpath>
+</com.jboss.devstudio.core.installer.PathInputPanel>
+<com.jboss.devstudio.core.installer.JREPathPanel id="jre"/>
+<com.jboss.devstudio.core.installer.JBossAsSelectPanel id="as">
+<installgroup>jbds</installgroup>
+</com.jboss.devstudio.core.installer.JBossAsSelectPanel>
+<com.jboss.devstudio.core.installer.UpdatePacksPanel id="updatepacks"/>
+<com.jboss.devstudio.core.installer.DiskSpaceCheckPanel id="diskspacecheck"/>
+<com.izforge.izpack.panels.SummaryPanel id="summary"/>
+<com.izforge.izpack.panels.InstallPanel id="install"/>
+<com.jboss.devstudio.core.installer.CreateLinkPanel id="createlink">
+<jrelocation>${java.home}/bin/java</jrelocation>
+</com.jboss.devstudio.core.installer.CreateLinkPanel>
+<com.izforge.izpack.panels.ShortcutPanel id="shortcut"/>
+<com.jboss.devstudio.core.installer.ShortcutPanelPatch id="shortcutpatch"/>
+<com.izforge.izpack.panels.SimpleFinishPanel id="finish"/>
+</AutomatedInstallation>

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -172,12 +172,17 @@
                   <!-- properties previously included in version.properties -->
                   <property name="project.version" value="${project.version}" />
                   <property name="BUILD_ALIAS" value="${BUILD_ALIAS}"/>
+                  <property name="project.build.directory" value="${project.build.directory}" />
+                  <property name="basedir" value="${basedir}" />
                 </ant>
                 <!-- clean up build-time artifacts so they won't be published -->
                 <delete includeEmptyDirs="true" quiet="true">
                   <fileset dir="${project.build.directory}/update"/>
                   <fileset file="${project.build.directory}/jbdevstudio-product-installer-Update-${buildQualifier}.zip"/>
                 </delete>
+
+                <!-- test installer jar -->
+
               </tasks>
             </configuration>
             <goals>

--- a/installer/src/panels/com/jboss/devstudio/core/installer/P2DirectorStarterListener.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/P2DirectorStarterListener.java
@@ -87,6 +87,7 @@ public class P2DirectorStarterListener implements InstallerListener {
 	}
 	
 	public static class BaseConsoleCommand implements ConsoleCommand, ResponseListener {
+		protected static final String EOL = System.getProperty("line.separator");
 		private final JavaVersionReader rt = new JavaVersionReader();
 		protected String cmd = "";
 		private List<String> parameters = new ArrayList<String>();
@@ -150,7 +151,7 @@ public class P2DirectorStarterListener implements InstallerListener {
 
 		@Override
 		public void stdout(String line) {
-			Debug.trace(line);
+			Debug.trace(line.replace(EOL,""));
 			if(!completePattern.matcher(line).matches() && line.contains("=")) {
 				bundles.add(line.substring(0,line.indexOf('=')));
 			}
@@ -188,7 +189,7 @@ public class P2DirectorStarterListener implements InstallerListener {
 
 		@Override
 		public void stdout(String line) {
-			Debug.trace(line);
+			Debug.trace(line.replace(EOL,""));
 			if(line.contains("Downloading")) {
 				downloadProgress(counter+=DOWNLOADING_WEIGHT,"Fetching " + line.substring(line.indexOf(' ')));
 			} else if(line.contains("Configuring") || line.contains("Installing")) {


### PR DESCRIPTION
Fix contains:
1. Suport for java policies
2. java.policy file that ahs all required permission except internet access
3. Test execution for installer in automated mode with -DskipTests support
4. Extra lines removed when tracing enabled with -DTRACE=true
5. Code duplication removed from several classes
