### PR TITLE
[JBDS-3427] Cleanup unused images from ${INSTALL_PATH}/studio folder

### DIFF
--- a/installer/src/config/install-pack-installer.xml
+++ b/installer/src/config/install-pack-installer.xml
@@ -16,9 +16,8 @@
 
       <singlefile src="config/resources/jbdevstudio-unity" target="$INSTALL_PATH/jbdevstudio-unity" condition="izpack.linuxinstall" />
       <executable targetfile="$INSTALL_PATH/jbdevstudio-unity" condition="izpack.linuxinstall" />
-      <fileset dir="config/resources/icons" targetdir="$INSTALL_PATH/studio">
-        <include name="*"/>
-      </fileset>
+      <singlefile src="config/resources/icons/jbds.ico" target="$INSTALL_PATH/studio/jbds.ico" os="windows" />
+      <singlefile src="config/resources/icons/jbds_uninstall.ico" target="$INSTALL_PATH/studio/jbds_uninstall.ico" os="windows" />
 
       <singlefile src="config/resources/jbdevstudio.bat" target="$INSTALL_PATH/jbdevstudio.bat" os="windows" />
       <parsable targetfile="$INSTALL_PATH/jbdevstudio.bat" os="windows" />


### PR DESCRIPTION
Only .ico files are used under winows for launchers in Start menu.
