### PR TITLE
JBDS-3490 Add Capabilities preference page into devstudio package

### DIFF
--- a/features/com.jboss.devstudio.core.capabilities.feature.source/.project
+++ b/features/com.jboss.devstudio.core.capabilities.feature.source/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.jboss.devstudio.core.capabilities.feature.source</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/features/com.jboss.devstudio.core.capabilities.feature.source/build.properties
+++ b/features/com.jboss.devstudio.core.capabilities.feature.source/build.properties
@@ -1,0 +1,2 @@
+bin.includes = feature.xml,\
+               feature.properties

--- a/features/com.jboss.devstudio.core.capabilities.feature.source/feature.properties
+++ b/features/com.jboss.devstudio.core.capabilities.feature.source/feature.properties
@@ -1,0 +1,36 @@
+###############################################################################
+# Copyright (c) 2008-2015 Red Hat, Inc. and others.
+# All rights reserved. This program and the accompanying materials 
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+# 
+# Contributors:
+# Red Hat, Inc. - Initial implementation.
+##############################################################################
+# feature.properties
+# contains externalized strings for feature.xml
+# "%foo" in feature.xml corresponds to the key "foo" in this file
+# java.io.Properties file (ISO 8859-1 with "\" escapes)
+# This file should be translated.
+
+# "featureName" property - name of the feature
+featureName=JBoss Developer Studio Cababilities Sources
+
+# "providerName" property - name of the company that provides the feature
+providerName=JBoss by Red Hat
+
+# "description" property - description of the feature
+description=This feature contains sources of JBoss Developer Studio Capablities feature.
+
+# "copyright" property - text of the "Feature Update Copyright"
+copyright=Copyright (c) 2008-2015 Red Hat, Inc. and others.\nAll rights reserved. This program and the accompanying materials\n 
+are made available under the terms of the Eclipse Public License v1.0\n\
+which accompanies this distribution, and is available at\n\
+http\://www.eclipse.org/legal/epl-v10.html\n\
+\n\
+Contributors\:\n\
+Red Hat, Inc. - Initial implementation.\n
+ ############### end of copyright property ####################################
+
+licenseURL=license.html

--- a/features/com.jboss.devstudio.core.capabilities.feature.source/feature.xml
+++ b/features/com.jboss.devstudio.core.capabilities.feature.source/feature.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="com.jboss.devstudio.core.capabilities.feature.source"
+      label="%featureName"
+      version="9.0.0.qualifier"
+      provider-name="%providerName"
+      license-feature="org.jboss.tools.foundation.license.feature"
+      license-feature-version="0.0.0"
+      plugin="com.jboss.devstudio.core">
+
+   <description url="https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio/">
+      %description
+   </description>
+
+   <copyright>
+      %copyright
+   </copyright>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <includes
+         id="com.jboss.devstudio.core.capabilities.feature"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.jboss.devstudio.core.capabilities.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+</feature>

--- a/features/com.jboss.devstudio.core.capabilities.feature.source/pom.xml
+++ b/features/com.jboss.devstudio.core.capabilities.feature.source/pom.xml
@@ -1,0 +1,14 @@
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.jboss.devstudio.core</groupId>
+		<artifactId>features</artifactId>
+		<version>9.0.0-SNAPSHOT</version>
+	</parent>
+	<groupId>com.jboss.devstudio.core.features</groupId>
+	<artifactId>com.jboss.devstudio.core.capabilities.feature.source</artifactId>
+	<version>9.0.0-SNAPSHOT</version>
+	<packaging>eclipse-feature</packaging>
+</project>

--- a/features/com.jboss.devstudio.core.capabilities.feature/.project
+++ b/features/com.jboss.devstudio.core.capabilities.feature/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.jboss.devstudio.core.capabilities.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/features/com.jboss.devstudio.core.capabilities.feature/build.properties
+++ b/features/com.jboss.devstudio.core.capabilities.feature/build.properties
@@ -1,0 +1,2 @@
+bin.includes = feature.xml,\
+               feature.properties

--- a/features/com.jboss.devstudio.core.capabilities.feature/feature.properties
+++ b/features/com.jboss.devstudio.core.capabilities.feature/feature.properties
@@ -1,0 +1,36 @@
+###############################################################################
+# Copyright (c) 2008-2015 Red Hat, Inc. and others.
+# All rights reserved. This program and the accompanying materials 
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+# 
+# Contributors:
+# Red Hat, Inc. - Initial implementation.
+##############################################################################
+# feature.properties
+# contains externalized strings for feature.xml
+# "%foo" in feature.xml corresponds to the key "foo" in this file
+# java.io.Properties file (ISO 8859-1 with "\" escapes)
+# This file should be translated.
+
+# "featureName" property - name of the feature
+featureName=JBoss Developer Studio Capabilities
+
+# "providerName" property - name of the company that provides the feature
+providerName=JBoss by Red Hat
+
+# "description" property - description of the feature
+description=This feature contains Capabilities preference page for JBoss Developer Studio.
+
+# "copyright" property - text of the "Feature Update Copyright"
+copyright=Copyright (c) 2008-2015 Red Hat, Inc. and others.\nAll rights reserved. This program and the accompanying materials\n 
+are made available under the terms of the Eclipse Public License v1.0\n\
+which accompanies this distribution, and is available at\n\
+http\://www.eclipse.org/legal/epl-v10.html\n\
+\n\
+Contributors\:\n\
+Red Hat, Inc. - Initial implementation.\n
+ ############### end of copyright property ####################################
+
+licenseURL=license.html

--- a/features/com.jboss.devstudio.core.capabilities.feature/feature.xml
+++ b/features/com.jboss.devstudio.core.capabilities.feature/feature.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="com.jboss.devstudio.core.capabilities.feature"
+      label="%featureName"
+      version="9.0.0.qualifier"
+      provider-name="%providerName"
+      plugin="com.jboss.devstudio.core"
+      license-feature="org.jboss.tools.foundation.license.feature"
+      license-feature-version="0.0.0">
+
+   <description url="https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio/">
+      %description
+   </description>
+
+   <copyright>
+      %copyright
+   </copyright>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <requires>
+   </requires>
+
+   <plugin
+         id="com.jboss.devstudio.core.capabilities"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/features/com.jboss.devstudio.core.capabilities.feature/pom.xml
+++ b/features/com.jboss.devstudio.core.capabilities.feature/pom.xml
@@ -1,0 +1,14 @@
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.jboss.devstudio.core</groupId>
+		<artifactId>features</artifactId>
+		<version>9.0.0-SNAPSHOT</version>
+	</parent>
+	<groupId>com.jboss.devstudio.core.features</groupId>
+	<artifactId>com.jboss.devstudio.core.capabilities.feature</artifactId>
+	<version>9.0.0-SNAPSHOT</version>
+	<packaging>eclipse-feature</packaging>
+</project>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -15,6 +15,8 @@
 	<modules>
 		<module>com.jboss.devstudio.core.feature</module>
 		<module>com.jboss.devstudio.core.feature.source</module>
+		<module>com.jboss.devstudio.core.capabilities.feature</module>
+		<module>com.jboss.devstudio.core.capabilities.feature.source</module>
 	</modules>
 </project>
 	

--- a/plugins/com.jboss.devstudio.core.capabilities/.classpath
+++ b/plugins/com.jboss.devstudio.core.capabilities/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/plugins/com.jboss.devstudio.core.capabilities/.eclipseproduct
+++ b/plugins/com.jboss.devstudio.core.capabilities/.eclipseproduct
@@ -1,0 +1,5 @@
+#Eclipse Product File
+
+version=2.0.0.GA
+name=JBoss Developer Studio
+id=com.jboss.devstudio.core.product

--- a/plugins/com.jboss.devstudio.core.capabilities/.project
+++ b/plugins/com.jboss.devstudio.core.capabilities/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.jboss.devstudio.core.capabilities</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/com.jboss.devstudio.core.capabilities/META-INF/MANIFEST.MF
+++ b/plugins/com.jboss.devstudio.core.capabilities/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %BundleName
+Bundle-SymbolicName: com.jboss.devstudio.core.capabilities;singleton:=true
+Bundle-Version: 9.0.0.qualifier
+Bundle-Vendor: %BundleVendor
+Bundle-Localization: plugin
+Bundle-ActivationPolicy: lazy
+Require-Bundle: org.eclipse.ui.workbench;bundle-version="3.107.0"

--- a/plugins/com.jboss.devstudio.core.capabilities/build.properties
+++ b/plugins/com.jboss.devstudio.core.capabilities/build.properties
@@ -1,0 +1,13 @@
+source.. = src/
+output.. = bin/
+bin.includes = plugin*,\
+               META-INF/,\
+               plugin.properties,\
+               plugin.xml
+src.includes = plugin*,\
+               META-INF/,\
+               build.properties,\
+               .project,\
+               .classpath
+src.includes = *
+src.excludes = src

--- a/plugins/com.jboss.devstudio.core.capabilities/plugin.properties
+++ b/plugins/com.jboss.devstudio.core.capabilities/plugin.properties
@@ -1,0 +1,10 @@
+#Properties 
+BundleVendor = JBoss by Red Hat
+BundleName = JBoss Developer Studio Capabilities
+
+PreferencePages.Capabilities = Capabilities
+PreferencePages.Capabilities.activityName = &Capabilities
+PreferencePages.Capabilities.categoryName = &Capabilities
+PreferencePages.Capabilities.activityPromptButton = &Prompt when enabling capabilities
+PreferencePages.Capabilities.activityPromptButtonTooltip = Prompt when a feature is first used that requires enablement of capabilities
+PreferencePages.Capabilities.captionMessage = Capabilities allow you to enable or disable various product components.  These capabilities are grouped according to a set of predefined categories.

--- a/plugins/com.jboss.devstudio.core.capabilities/plugin.xml
+++ b/plugins/com.jboss.devstudio.core.capabilities/plugin.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.2"?>
+<plugin>
+    <extension
+        point="org.eclipse.ui.preferencePages">
+        <page
+            category="org.eclipse.ui.preferencePages.Workbench"
+            name="%PreferencePages.Capabilities"
+            id="com.jboss.devstudio.core.capabilities">
+            <class
+                class="org.eclipse.ui.activities.ActivityCategoryPreferencePage">
+                <parameter
+                    name="allowAdvanced"
+                    value="true"/>
+                <parameter
+                    name="captionMessage"
+                    value="%PreferencePages.Capabilities.captionMessage"/>
+                <parameter
+                    name="activityName"
+                    value="%PreferencePages.Capabilities.activityName"/>
+                <parameter
+                    name="categoryName"
+                    value="%PreferencePages.Capabilities.categoryName"/>
+                <parameter
+                    name="activityPromptButton"
+                    value="%PreferencePages.Capabilities.activityPromptButton"/>
+                <parameter
+                    name="activityPromptButtonTooltip"
+                    value="%PreferencePages.Capabilities.activityPromptButtonTooltip"/>
+            </class>
+        </page>
+    </extension>
+</plugin>

--- a/plugins/com.jboss.devstudio.core.capabilities/pom.xml
+++ b/plugins/com.jboss.devstudio.core.capabilities/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.jboss.devstudio.core</groupId>
+    <artifactId>plugins</artifactId>
+    <version>9.0.0-SNAPSHOT</version>
+  </parent>
+  <groupId>com.jboss.devstudio.core.plugins</groupId>
+  <artifactId>com.jboss.devstudio.core.capabilities</artifactId>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -16,6 +16,7 @@
 		<module>com.jboss.devstudio.core.project.examples</module>
 		<module>com.jboss.devstudio.core.usage.branding</module>
 		<module>com.jboss.devstudio.core.central</module>
+		<module>com.jboss.devstudio.core.capabilities</module>
 	</modules>
 </project>
 	

--- a/site/category.xml
+++ b/site/category.xml
@@ -296,7 +296,11 @@
   <feature id="org.jboss.tools.usage.feature"/>
 
   <!-- only in JBDS -->
-  <feature id="com.jboss.devstudio.core.feature" patch="false"><category name="BringYourOwnEclipse" /><category name="CoreTools" /></feature>
+  <feature id="com.jboss.devstudio.core.feature" patch="false">
+    <category name="BringYourOwnEclipse" />
+    <category name="CoreTools" />
+  </feature>
+  <feature id="com.jboss.devstudio.core.capabilities.feature"/>
   <feature id="org.eclipse.egit"/>
   <feature id="org.eclipse.jgit"/>
   <feature id="org.eclipse.m2e.feature"/>
@@ -386,7 +390,7 @@
 
   <!-- only in JBDS -->
   <feature id="com.jboss.devstudio.core.feature.source" patch="false"/>
-
+  <feature id="com.jboss.devstudio.core.capabilities.feature.source" patch="false"/>
 
   <!-- ########## -->
   <!-- CATEGORIES -->

--- a/site/com.jboss.devstudio.core.product
+++ b/site/com.jboss.devstudio.core.product
@@ -58,11 +58,9 @@ openFile</programArgs>
          </text>
    </license>
 
-   <plugins>
-   </plugins>
-
    <features>
       <feature id="com.jboss.devstudio.core.feature"/>
+      <feature id="com.jboss.devstudio.core.capabilities.feature"/>
    </features>
 
    <configurations>


### PR DESCRIPTION
Fix contains new capabilities bundle and feature to add missin Capabilities
preference page into devstudio. Feature is required to include capabilities
bundle into devstudio product assembly because it is features based.
Capabilities feature included only into product and is not presented in
BYOE feature.
