### PR TITLE
[JBDS-3581] Installer does not allow Java 9 EA

### DIFF
--- a/installer/src/panels/com/jboss/devstudio/core/installer/JREPathPanel.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/JREPathPanel.java
@@ -353,11 +353,18 @@ public class JREPathPanel extends PathInputPanel implements IChangeListener {
 			return -5;
 		}
 
-        if(!detectedVersion.matches("1\\.[1-9]\\.[0-9].*")) {
-        	return -4; // Unknown version
-        }
-        int versionNumber = Integer.parseInt(detectedVersion.substring(2,3)); 
-        
+		if(!detectedVersion.matches("1\\.[1-9]\\.[0-9].*") && !detectedVersion.matches("[1-9]-.*")) {
+			return -4; // Unknown version
+		}
+
+		int versionNumber = 0;
+
+		if (detectedVersion.matches("1\\.[1-9]\\.[0-9].*")) {
+			 versionNumber = Integer.parseInt(detectedVersion.substring(2, 3));
+		} else {
+			versionNumber = 9;
+		}
+
         if (versionNumber < minVersion) {
         	return -3; // Version is less that minimum version
         }

--- a/installer/src/panels/com/jboss/devstudio/core/installer/JREPathValidator.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/JREPathValidator.java
@@ -118,11 +118,16 @@ public class JREPathValidator {
 			return ValidationCode.ERR_JVM_VERSION_NOT_FOUND;
 		}
 		// Check detected version format
-		if (!detectedVersion.matches("1\\.[1-9]\\.[0-9].*")) {
+		if (!detectedVersion.matches("1\\.[1-9]\\.[0-9].*") && !detectedVersion.matches("[1-9]-.*")) {
 			// Unknown version
 			return ValidationCode.ERR_JVM_VERSION_NOT_PARSED; 
 		}
-		int versionNumber = Integer.parseInt(detectedVersion.substring(2, 3));
+		int versionNumber = 0;
+		if (detectedVersion.matches("1\\.[1-9]\\.[0-9].*")) {
+			 versionNumber = Integer.parseInt(detectedVersion.substring(2, 3));
+		} else {
+			versionNumber = 9;
+		}
 
 		// check selected JVM version range
 		if (versionNumber < MIN_VERSION) {

--- a/installer/src/test/com/jboss/devstudio/core/installer/GsonSerializationTest.java
+++ b/installer/src/test/com/jboss/devstudio/core/installer/GsonSerializationTest.java
@@ -1,5 +1,6 @@
 package com.jboss.devstudio.core.installer;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
@@ -8,14 +9,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
-import junit.framework.TestCase;
-
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.izforge.izpack.installer.Unpacker;
 import com.jboss.devstudio.core.installer.bean.P2IU;
+
+import junit.framework.TestCase;
 
 public class GsonSerializationTest extends TestCase {
 
@@ -32,7 +33,7 @@ public class GsonSerializationTest extends TestCase {
 	
 	public void testIULoadFromFile() throws FileNotFoundException {
 		
-		InputStream features = new FileInputStream("/home/eskimo/Projects/jbdevstudio/4.4.x/fork/jbds-releng/jbdevstudio-product/installer/src/config/resources/DevstudioFeaturesSpec.json");
+		InputStream features = new FileInputStream(new File(CommonTestData.PROJECT_ROOT,"src/config/resources/DevstudioFeaturesSpec.json"));
 		JsonParser parser = new JsonParser();
 		JsonArray array = parser.parse(new InputStreamReader(features)).getAsJsonArray();
 		Gson gson = new Gson();

--- a/installer/src/test/com/jboss/devstudio/core/installer/JREPathValidatorTest.java
+++ b/installer/src/test/com/jboss/devstudio/core/installer/JREPathValidatorTest.java
@@ -85,7 +85,7 @@ public class JREPathValidatorTest extends TestCase {
 	}
 
 	public void testVerifyVersionJvmNotTested() {
-		ValidationCode result = createValidatorWithVersionOutput("1.9.0_64").runAndVerifyVersion("");
+		ValidationCode result = createValidatorWithVersionOutput("9-ea").runAndVerifyVersion("");
 		assertTrue(result == ValidationCode.WRN_JVM_VERSION_NOT_TESTED);
 	}
 
@@ -214,7 +214,7 @@ public class JREPathValidatorTest extends TestCase {
 				} else if (params[0].endsWith("8/bin/java")) {
 					output[0] = createOut("Oracle","1.8.0_41","64")[0];
 				} else if (params[0].endsWith("9/bin/java")) {
-					output[0] = createOut("Oracle","1.9.0_41","64")[0];
+					output[0] = createOut("Oracle","9-ea","64")[0];
 				} else {
 					output[0] = createOut("Oracle","1.8.0_41","64")[0];
 				}


### PR DESCRIPTION
Fix changes version detection algorithm to consider new pattern
fro Java 9 Early Access