### PR TITLE
JBIDE-22689: enable baselineRepositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
     <!-- <jbosstools_site_stream>master</jbosstools_site_stream> -->
     <jbosstools-site>http://download.jboss.org/jbosstools/${eclipseReleaseName}/snapshots/updates/core/${jbosstools_site_stream}/</jbosstools-site>
     <!-- <jbosstools-target-site>http://download.jboss.org/jbosstools/targetplatforms/jbdevstudiotarget/4.40.0.CR1-SNAPSHOT/REPO/</jbosstools-target-site> -->
+    <stagingBaselineRepository>https://devstudio.redhat.com/10.0/staging/updates/</stagingBaselineRepository>
+
 
     <!--
       By default, use EAP 6.1.0.Alpha, which is publically available. This allows devstudio to be build locally w/o needing access to devel.redhat.com


### PR DESCRIPTION
to ensure changes in code without a related commit are reported as errors, forcing timestamps increment for meta-changes too