### PR TITLE
JBDS-3996 Build the installer jar in package phase

### DIFF
--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -155,90 +155,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<version>${maven.antrun.plugin.version}</version>
-				<executions>
-					<execution>
-						<id>install</id>
-						<phase>install</phase>
-						<configuration>
-							<quiet>true</quiet>
-							<tasks>
-								<ant antfile="build.xml">
-									<property name="basedir" value="${basedir}" />
-									<property name="project.build.directory" value="${project.build.directory}" />
-									<property name="IzPackVersion" value="${IzPackVersion}"/>
-									<property name="buildEAPBundle" value="${buildEAPBundle}"/>
-									<property name="artifacts.p2-director" value="${project.build.directory}/requirements/p2-director.zip" />
-									<property name="artifacts.jbosseap" location="${project.build.directory}/requirements/${eapFilename}" />
-									<property name="eapRootFolder" value="${eapRootFolder}"/>
-									<property name="eapVersion" value="${eapVersion}" />
-									<property name="destination.dir" value="${project.build.directory}" />
-									<property name="izpack.home" value="${project.build.directory}/IzPack-${IzPackVersion}" />
-									<property name="skip.ant.actions" value="true" />
-									<property name="buildQualifier" value="${buildQualifier}" />
-									<property name="product.buildType" value="R" />
-									<property name="project.version" value="${project.version}" />
-									<property name="BUILD_ALIAS" value="${BUILD_ALIAS}"/>
-								</ant>
-							</tasks>
-						</configuration>
-						<goals>
-							<goal>run</goal>
-						</goals>
-					</execution>
-				</executions>
-				<dependencies>
-					<dependency>
-						<groupId>ant</groupId>
-						<artifactId>ant-optional</artifactId>
-						<version>1.5.3-1</version>
-					</dependency>
-					<dependency>
-						<groupId>commons-net</groupId>
-						<artifactId>commons-net</artifactId>
-						<version>1.4.1</version>
-					</dependency>
-					<dependency>
-						<groupId>org.apache.ant</groupId>
-						<artifactId>ant</artifactId>
-						<version>1.7.1</version>
-					</dependency>
-					<dependency>
-						<groupId>org.apache.ant</groupId>
-						<artifactId>ant-nodeps</artifactId>
-						<version>1.7.1</version>
-					</dependency>
-					<dependency>
-						<groupId>org.apache.ant</groupId>
-						<artifactId>ant-trax</artifactId>
-						<version>1.7.1</version>
-					</dependency>
-					<dependency>
-						<groupId>org.apache.ant</groupId>
-						<artifactId>ant-commons-net</artifactId>
-						<version>1.7.1</version>
-					</dependency>
-					<dependency>
-						<groupId>org.apache.ant</groupId>
-						<artifactId>ant-apache-regexp</artifactId>
-						<version>1.7.1</version>
-					</dependency>
-					<dependency>
-						<groupId>ant-contrib</groupId>
-						<artifactId>ant-contrib</artifactId>
-						<version>1.0b3</version>
-					</dependency>
-					<dependency>
-						<groupId>com.sun</groupId>
-						<artifactId>tools</artifactId>
-						<version>1.5.0</version>
-						<scope>system</scope>
-						<systemPath>${java.home}/../lib/tools.jar</systemPath>
-					</dependency>
-				</dependencies>
-			</plugin>
 					<plugin>
 						<groupId>org.eclipse.tycho</groupId>
 						<artifactId>target-platform-configuration</artifactId>
@@ -305,12 +221,96 @@
 							</execution>
 						</executions>
 				</plugin>
+				<plugin>
+					<artifactId>maven-antrun-plugin</artifactId>
+					<version>${maven.antrun.plugin.version}</version>
+					<executions>
+						<execution>
+							<id>install</id>
+							<phase>package</phase>
+							<configuration>
+								<quiet>true</quiet>
+								<tasks>
+									<ant antfile="build.xml">
+										<property name="basedir" value="${basedir}" />
+										<property name="project.build.directory" value="${project.build.directory}" />
+										<property name="IzPackVersion" value="${IzPackVersion}"/>
+										<property name="buildEAPBundle" value="${buildEAPBundle}"/>
+										<property name="artifacts.p2-director" value="${project.build.directory}/requirements/p2-director.zip" />
+										<property name="artifacts.jbosseap" location="${project.build.directory}/requirements/${eapFilename}" />
+										<property name="eapRootFolder" value="${eapRootFolder}"/>
+										<property name="eapVersion" value="${eapVersion}" />
+										<property name="destination.dir" value="${project.build.directory}" />
+										<property name="izpack.home" value="${project.build.directory}/IzPack-${IzPackVersion}" />
+										<property name="skip.ant.actions" value="true" />
+										<property name="buildQualifier" value="${buildQualifier}" />
+										<property name="product.buildType" value="R" />
+										<property name="project.version" value="${project.version}" />
+										<property name="BUILD_ALIAS" value="${BUILD_ALIAS}"/>
+									</ant>
+								</tasks>
+							</configuration>
+							<goals>
+								<goal>run</goal>
+							</goals>
+						</execution>
+					</executions>
+					<dependencies>
+						<dependency>
+							<groupId>ant</groupId>
+							<artifactId>ant-optional</artifactId>
+							<version>1.5.3-1</version>
+						</dependency>
+						<dependency>
+							<groupId>commons-net</groupId>
+							<artifactId>commons-net</artifactId>
+							<version>1.4.1</version>
+						</dependency>
+						<dependency>
+							<groupId>org.apache.ant</groupId>
+							<artifactId>ant</artifactId>
+							<version>1.7.1</version>
+						</dependency>
+						<dependency>
+							<groupId>org.apache.ant</groupId>
+							<artifactId>ant-nodeps</artifactId>
+							<version>1.7.1</version>
+						</dependency>
+						<dependency>
+							<groupId>org.apache.ant</groupId>
+							<artifactId>ant-trax</artifactId>
+							<version>1.7.1</version>
+						</dependency>
+						<dependency>
+							<groupId>org.apache.ant</groupId>
+							<artifactId>ant-commons-net</artifactId>
+							<version>1.7.1</version>
+						</dependency>
+						<dependency>
+							<groupId>org.apache.ant</groupId>
+							<artifactId>ant-apache-regexp</artifactId>
+							<version>1.7.1</version>
+						</dependency>
+						<dependency>
+							<groupId>ant-contrib</groupId>
+							<artifactId>ant-contrib</artifactId>
+							<version>1.0b3</version>
+						</dependency>
+						<dependency>
+							<groupId>com.sun</groupId>
+							<artifactId>tools</artifactId>
+							<version>1.5.0</version>
+							<scope>system</scope>
+							<systemPath>${java.home}/../lib/tools.jar</systemPath>
+						</dependency>
+					</dependencies>
+				</plugin>
 			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 				<executions>
 					<execution>
-						<phase>install</phase>
+						<phase>package</phase>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
Until now, the installer jar was only built in the installer phase.
That's because the izpack ant call had install phase set.
I think it makes sense to do this in package phase already.
From maven.apache.org:
install - install the package into the local repository, for use as a dependency in other projects locally