### PR TITLE
JBDS-4012 - correct intermittent NPE in izPack unpacker progress monitor

### DIFF
--- a/installer/src/panels/com/izforge/izpack/installer/Unpacker.java
+++ b/installer/src/panels/com/izforge/izpack/installer/Unpacker.java
@@ -862,10 +862,10 @@ public class Unpacker extends UnpackerBase
 
 		for (int i = 0; i < rtl.length; i++) {			
 			runtimeEntry = jar.getJarEntry(rtl[i]);
-			handler.progress(i + 1, "Runtime " + runtimeEntry.getName());
 	
 	    	// Standard jar file extraction if an RT server exists.
 	    	if (runtimeEntry != null) {
+			handler.progress(i + 1, "Runtime " + runtimeEntry.getName());
 	    		String[] rtlComponents = rtl[i].split(java.io.File.separator);
 	    		File entryFile = new File(installLocation, rtlComponents[0]);
 	    	    entryFile.setLastModified(runtimeEntry.getTime());


### PR DESCRIPTION
@dgolovin - Found an intermittent npe in the new unpacker code for added runtimes.  It's a one-line change - please review?  thkx!!