### PR TITLE
Blacklist the Jersey/Jackson/HK2 stack.

### DIFF
--- a/rpm/devstudio.blacklist.txt
+++ b/rpm/devstudio.blacklist.txt
@@ -28,6 +28,32 @@ javax.ws.rs-api
 # ./usr/lib64/eclipse/plugins/org.eclipse.osgi_3.11.0.v20160819-1000.jar
 org.eclipse.osgi
 
+#➔ find . -name org.glassfish.jersey.\*
+#./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.glassfish.jersey.apache.connector_2.14.0.v201504171603.jar
+#./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.glassfish.jersey.bundles.repackaged.jersey-guava_2.14.0.v201504151636.jar
+#./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.glassfish.jersey.core.jersey-client_2.14.0.v201504211925.jar
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.glassfish.jersey.core.jersey-common_2.14.0.v201504171603.jar
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.glassfish.jersey.media.jersey-media-json-jackson_2.14.0.v201504171603.jar
+org.glassfish.jersey.apache.connector
+org.glassfish.jersey.bundles.repackaged.jersey-guava
+org.glassfish.jersey.core.jersey-client
+org.glassfish.jersey.core.jersey-common
+org.glassfish.jersey.media.jersey-media-json-jackson
+
+#➔ find . -name com.fasterxml.jackson.\*
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/com.fasterxml.jackson.core.jackson-annotations_2.5.0.v201504151636.jar
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/com.fasterxml.jackson.core.jackson-core_2.5.0.v201504151636.jar
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/com.fasterxml.jackson.core.jackson-databind_2.5.0.v201504151636.jar
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/com.fasterxml.jackson.datatype.jackson-datatype-guava_2.5.0.v201504151636.jar
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/com.fasterxml.jackson.jaxrs.jackson-jaxrs-base_2.5.0.v201504171603.jar
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider_2.5.0.v201504171603.jar
+com.fasterxml.jackson.core.jackson-annotations
+com.fasterxml.jackson.core.jackson-core
+com.fasterxml.jackson.core.jackson-databind
+com.fasterxml.jackson.datatype.jackson-datatype-guava
+com.fasterxml.jackson.jaxrs.jackson-jaxrs-base
+com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider
+
 #➔ find . -name org.glassfish.hk2.\*
 #./usr/share/eclipse/droplets/linuxtools-docker/eclipse/plugins/org.glassfish.hk2.locator_2.4.0.jar
 #./usr/share/eclipse/droplets/linuxtools-docker/eclipse/plugins/org.glassfish.hk2.api_2.4.0.jar
@@ -41,6 +67,29 @@ org.glassfish.hk2.api
 org.glassfish.hk2.locator
 org.glassfish.hk2.osgi-resource-locator
 org.glassfish.hk2.utils
+
+#➔ find . -name com.google.guava.\*
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/com.google.guava_15.0.0.v201403281430.jar
+com.google.guava
+
+#➔ find . -name javassist.\*
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/javassist_3.13.0.GA_v201209210905.jar
+javassist
+
+#➔ find . -name org.bouncycastle.\*
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.bouncycastle.bcpkix_1.51.0.v201505131810.jar
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.bouncycastle.bcprov_1.51.0.v201505131810.jar
+org.bouncycastle.bcprov
+org.bouncycastle.bcpkix
+
+#➔ find . -name org.objectweb.asm.\*
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.objectweb.asm.commons_5.0.1.v201404251740.jar
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.objectweb.asm.tree_5.0.1.v201404251740.jar
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.objectweb.asm_5.0.1.v201404251740.jar
+# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.objectweb.asm_4.0.0.v201302062210.jar
+org.objectweb.asm.commons
+org.objectweb.asm.tree
+org.objectweb.asm
 
 # removed because available in upstream eclipse-* or rh-eclipse* packages
 # list computed by looking at buildlog and scanning for "[INFO osgi.prov] rh-eclipse46-osgi" lines


### PR DESCRIPTION
The *jersey*, *jackson*, *hk2* bundles are provided by the Eclipse
Docker Tooling along with a few other lower level depdendencies.

I'm wondering about the format for this file. I noticed that the bundles listed at the bottom are meant to represent things that are provided by other droplets. However, I also see bundles above that (formatted with comments) that are provided by other droplets, so it seems things are mixed.

Just a heads-up that I may need to change where some bundles are listed to avoid confusion.