### PR TITLE
JBDS-4075 Installer produces invalid install config xml

### DIFF
--- a/installer/src/panels/com/jboss/devstudio/core/installer/InstallAdditionalRuntimesPanelAutomationHelper.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/InstallAdditionalRuntimesPanelAutomationHelper.java
@@ -34,7 +34,7 @@ public class InstallAdditionalRuntimesPanelAutomationHelper implements PanelAuto
 
 	public void runAutomated(AutomatedInstallData idata, IXMLElement panelRoot) throws InstallerException {
 		IXMLElement locations = panelRoot.getFirstChildNamed(LOCATIONS_NODE_NAME);
-		if (locations != null) {
+		if (locations != null && locations.getContent() != null) {
 			idata.setVariable(Unpacker.INSTALL_RT_LOCATIONS_VAR, locations.getContent());
 		}
 	}


### PR DESCRIPTION
Fix adds verification that location element for additional runtimes
has content.