### PR TITLE
JBDS-4076 use static value of RPM_VERSION...

### DIFF
--- a/rpm/.gitignore
+++ b/rpm/.gitignore
@@ -5,3 +5,4 @@ devstudio-*.src.rpm
 devstudio.tar.xz
 yum_repo/
 mock_logs/
+devstudio.spec

--- a/rpm/devstudio.spec.template
+++ b/rpm/devstudio.spec.template
@@ -1,14 +1,13 @@
 %{?scl:%scl_package devstudio}
 %{!?scl:%global pkg_name %{name}}
 %{?java_common_find_provides_and_requires}
-# %{expand: %%global _datetime %(date -u +%Y%m%d.%H%M)}
 
 # Prevent useless debuginfo package generation
 %global debug_package %{nil}
 
 Name:           %{?scl_prefix}devstudio
-Version:        10.2
-Release:        0.%{_datetime}%{?dist}
+Version:        RPM_VERSION
+Release:        RPM_BUILD_VERSION%{?dist}
 Summary:        Red Hat Developer Studio
 
 License:        EPL


### PR DESCRIPTION
JBDS-4076 use static value of RPM_VERSION and RPM_BUILD_VERSION as generated from current datetime and the version in ../pom.xml; add devstudio.spec.template and move devstudio.spec to .gitignore as it's now a generated file