### PR TITLE
JBDS-4014 remove...

### DIFF
--- a/features/com.jboss.devstudio.core.feature/feature.xml
+++ b/features/com.jboss.devstudio.core.feature/feature.xml
@@ -22,5 +22,6 @@
 
   <includes id="com.jboss.devstudio.core.rpm.feature" version="0.0.0"/>
   <includes id="com.jboss.devstudio.core.rpmdeps.feature" version="0.0.0"/>
+  <includes id="org.jboss.tools.usage.feature" version="0.0.0"/>
 
  </feature>

--- a/features/com.jboss.devstudio.core.rpm.feature/feature.xml
+++ b/features/com.jboss.devstudio.core.rpm.feature/feature.xml
@@ -55,7 +55,6 @@
   <includes id="org.jboss.tools.livereload.feature" version="0.0.0"/>
   <includes id="org.jboss.tools.jst.feature" version="0.0.0"/>
   <includes id="org.jboss.tools.jst.jsdt.feature" version="0.0.0"/>
-  <includes id="org.jboss.tools.usage.feature" version="0.0.0"/>
 
   <plugin id="org.jboss.tools.discovery.core" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
   <plugin id="org.jboss.tools.foundation.help.ui" download-size="0" install-size="0" version="0.0.0" unpack="false"/>

--- a/rpm/devstudio.blacklist.txt
+++ b/rpm/devstudio.blacklist.txt
@@ -148,3 +148,7 @@ org.eclipse.ui.views.log
 org.w3c.css.sac
 org.w3c.dom.events
 org.w3c.dom.smil
+
+# removed because excluded from devstudio rpm (but included in the devstudio installer/udpate site)
+org.jboss.tools.usage.feature
+org.jboss.tools.usage

--- a/rpm/devstudio.removelist.txt
+++ b/rpm/devstudio.removelist.txt
@@ -572,6 +572,8 @@ org.glassfish.jersey.bundles.repackaged.jersey-guava
 org.glassfish.jersey.core.jersey-client
 org.glassfish.jersey.core.jersey-common
 org.glassfish.jersey.media.jersey-media-json-jackson
+org.jboss.tools.usage.feature
+org.jboss.tools.usage
 org.objectweb.asm
 org.objectweb.asm.commons
 org.objectweb.asm.tree


### PR DESCRIPTION
JBDS-4014 remove org.jboss.tools.usage.feature from devstudio rpm since it's now part of upstream rh-eclipse46-base