### PR TITLE
JBDS-4135 remove o.e.mylyn.* bundles which...

### DIFF
--- a/rpm/devstudio.blacklist.txt
+++ b/rpm/devstudio.blacklist.txt
@@ -142,3 +142,11 @@ org.eclipse.ui.views.log
 org.w3c.css.sac
 org.w3c.dom.events
 org.w3c.dom.smil
+
+# JBDS-4135 removed to avoid having duplicate singletons
+org.eclipse.mylyn.commons.core
+org.eclipse.mylyn.commons.net
+org.eclipse.mylyn.commons.notifications.core
+org.eclipse.mylyn.commons.notifications.ui
+org.eclipse.mylyn.commons.ui
+org.eclipse.mylyn.commons.workbench

--- a/rpm/devstudio.removelist.txt
+++ b/rpm/devstudio.removelist.txt
@@ -333,6 +333,12 @@ org.eclipse.osgi
 org.eclipse.osgi.compatibility.state
 org.eclipse.osgi.services
 org.eclipse.osgi.util
+org.eclipse.mylyn.commons.core
+org.eclipse.mylyn.commons.net
+org.eclipse.mylyn.commons.notifications.core
+org.eclipse.mylyn.commons.notifications.ui
+org.eclipse.mylyn.commons.ui
+org.eclipse.mylyn.commons.workbench
 org.eclipse.pde
 org.eclipse.pde.api.tools
 org.eclipse.pde.api.tools.annotations


### PR DESCRIPTION
JBDS-4135 remove o.e.mylyn.* bundles which are dupe singletons (presumably because already included in rh-eclipse46-base)