### PR TITLE
JBDS-4134 add -org.objectweb.asm* plugins...

### DIFF
--- a/rpm/devstudio.blacklist.txt
+++ b/rpm/devstudio.blacklist.txt
@@ -80,15 +80,6 @@ javassist
 org.bouncycastle.bcprov
 org.bouncycastle.bcpkix
 
-#➔ find . -name org.objectweb.asm.\*
-# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.objectweb.asm.commons_5.0.1.v201404251740.jar
-# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.objectweb.asm.tree_5.0.1.v201404251740.jar
-# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.objectweb.asm_5.0.1.v201404251740.jar
-# ./opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets/devstudio/eclipse/plugins/org.objectweb.asm_4.0.0.v201302062210.jar
-org.objectweb.asm.commons
-org.objectweb.asm.tree
-org.objectweb.asm
-
 # removed because available in upstream eclipse-* or rh-eclipse* packages
 # list computed by looking at buildlog and scanning for "[INFO osgi.prov] rh-eclipse46-osgi" lines
 com.ibm.icu

--- a/rpm/devstudio.removelist.txt
+++ b/rpm/devstudio.removelist.txt
@@ -575,9 +575,6 @@ org.glassfish.jersey.bundles.repackaged.jersey-guava
 org.glassfish.jersey.core.jersey-client
 org.glassfish.jersey.core.jersey-common
 org.glassfish.jersey.media.jersey-media-json-jackson
-org.objectweb.asm
-org.objectweb.asm.commons
-org.objectweb.asm.tree
 org.sat4j.core
 org.sat4j.pb
 org.tukaani.xz


### PR DESCRIPTION
JBDS-4134 add -org.objectweb.asm* plugins back into devstudio as they're not available from upstream rpm