### PR TITLE
JBDS-4134 possibly overkill, but having the...

### DIFF
--- a/rpm/devstudio.spec.template
+++ b/rpm/devstudio.spec.template
@@ -26,6 +26,10 @@ Requires: ORBit2
 Requires: gnome-vfs2
 Requires: libnotify
 Requires: libIDL
+# cdt deps: org.eclipse.cdt.core.native and org.eclipse.cdt.core.utils.pty
+Requires: eclipse-cdt
+# rse deps: org.eclipse.rse.core and org.eclipse.rse.ui
+Requires: eclipse-rse
 
 # note that java-1.8.0-openjdk-devel should also be installed but that should be already required upstream
 Requires: java-1.8.0-openjdk-devel


### PR DESCRIPTION
JBDS-4134 possibly overkill, but having the devstudio rpm depend on eclipse-cdt and eclipse-rse rpms will resolve missing cdt/rse bundles