### PR TITLE
JBDS-4134 make rpm depend on three upstream...

### DIFF
--- a/rpm/devstudio.blacklist.txt
+++ b/rpm/devstudio.blacklist.txt
@@ -140,3 +140,14 @@ org.eclipse.mylyn.commons.notifications.core
 org.eclipse.mylyn.commons.notifications.ui
 org.eclipse.mylyn.commons.ui
 org.eclipse.mylyn.commons.workbench
+
+# JBDS-4134 remove stuff available from rh-eclipse46-eclipse-cdt-native
+org.eclipse.cdt.core.native
+
+# JBDS-4134 remove stuff available from rh-eclipse46-eclipse-rse
+org.eclipse.rse.core
+org.eclipse.rse.ui
+
+# JBDS-4134 remove stuff available from rh-eclipse46-eclipse-tm-terminal-connectors
+org.eclipse.tm.terminal.connector.local
+org.eclipse.tm.terminal.connector.local.feature

--- a/rpm/devstudio.removelist.txt
+++ b/rpm/devstudio.removelist.txt
@@ -397,6 +397,8 @@ org.eclipse.tm.terminal.connector.ssh
 org.eclipse.tm.terminal.connector.ssh.feature
 org.eclipse.tm.terminal.connector.telnet
 org.eclipse.tm.terminal.connector.telnet.feature
+org.eclipse.tm.terminal.connector.local
+org.eclipse.tm.terminal.connector.local.feature
 org.eclipse.tm.terminal.control
 org.eclipse.tm.terminal.control.feature
 org.eclipse.tm.terminal.view.core

--- a/rpm/devstudio.spec.template
+++ b/rpm/devstudio.spec.template
@@ -27,9 +27,11 @@ Requires: gnome-vfs2
 Requires: libnotify
 Requires: libIDL
 # cdt deps: org.eclipse.cdt.core.native and org.eclipse.cdt.core.utils.pty
-Requires: eclipse-cdt
+Requires: rh-eclipse46-eclipse-cdt-native
 # rse deps: org.eclipse.rse.core and org.eclipse.rse.ui
-Requires: eclipse-rse
+Requires: rh-eclipse46-eclipse-rse
+# tm deps: org.eclipse.tm.terminal.connector.local
+Requires: rh-eclipse46-eclipse-tm-terminal-connectors
 
 # note that java-1.8.0-openjdk-devel should also be installed but that should be already required upstream
 Requires: java-1.8.0-openjdk-devel


### PR DESCRIPTION
JBDS-4134 make rpm depend on three upstream rh-eclipse46-eclipse-* packages instead of just the eclipse-* packages; add dep on rh-eclipse46-eclipse-tm-terminal-connectors too