### PR TITLE
JBDS-4145 - Drop dep on obsolete o.e.core.runtime.compat.auth bundle

### DIFF
--- a/features/com.jboss.devstudio.core.rpm.feature/feature.xml
+++ b/features/com.jboss.devstudio.core.rpm.feature/feature.xml
@@ -96,7 +96,6 @@
     <import feature="org.sonatype.m2e.buildhelper.feature"/>
     <import feature="org.sonatype.m2e.egit.feature"/>
     <import feature="org.sonatype.m2e.mavenarchiver.feature"/>
-    <import plugin="org.eclipse.core.runtime.compatibility.auth" />
     <import plugin="org.eclipse.rse.core" version="3.3.100" match="greaterOrEqual" />
     <import plugin="org.eclipse.rse.files.ui" version="3.2.0" match="greaterOrEqual" />
     <import plugin="org.eclipse.rse.services" version="3.2.100" match="greaterOrEqual" />


### PR DESCRIPTION
I'd be extremely surprised if this bundle was needed by anything -- as I say in the bug report, this bundle is extremely obsolete.