### PR TITLE
JBDS-4149 blacklist javax.servlet (again) to...

### DIFF
--- a/rpm/devstudio.blacklist.txt
+++ b/rpm/devstudio.blacklist.txt
@@ -14,6 +14,7 @@ javax.annotation-api
 #./usr/share/eclipse/droplets/webtools-javaee/eclipse/plugins/javax.servlet_3.0.0.jar
 #./usr/share/eclipse/droplets/devstudio/eclipse/plugins/javax.servlet_3.1.0.v201410161800.jar
 #./usr/share/eclipse/droplets/devstudio/eclipse/plugins/javax.servlet.jsp_2.2.0.v201112011158.jar
+javax.servlet
 javax.servlet-api
 javax.servlet.jsp
 

--- a/rpm/devstudio.removelist.txt
+++ b/rpm/devstudio.removelist.txt
@@ -13,6 +13,7 @@ javassist
 javax.annotation
 javax.annotation-api
 javax.inject
+javax.servlet
 javax.servlet-api
 javax.servlet.jsp
 javax.ws.rs


### PR DESCRIPTION
JBDS-4149 blacklist javax.servlet (again) to prevent usage constraint violation from jgit, org.jboss.tools.browsersim.ui, org.jboss.tools.livereload.core - was previously removed to fix JBDS-4131