### PR TITLE
JBDS-4153 - correct Windows supplememtal runtime installation

### DIFF
--- a/installer/src/panels/com/izforge/izpack/installer/Unpacker.java
+++ b/installer/src/panels/com/izforge/izpack/installer/Unpacker.java
@@ -866,10 +866,7 @@ public class Unpacker extends UnpackerBase
 	    	// Standard jar file extraction if an RT server exists.
 	    	if (runtimeEntry != null) {
 			handler.progress(i + 1, "Runtime " + runtimeEntry.getName());
-				String separator = java.io.File.separator;
-				if (separator.equals("\\"))
-					separator = "/";
-	    		String[] rtlComponents = rtl[i].split(separator);
+	    		String[] rtlComponents = rtl[i].split("/");
 	    		File entryFile = new File(installLocation, rtlComponents[0]);
 	    	    entryFile.setLastModified(runtimeEntry.getTime());
 	            entryFile.getParentFile().mkdirs();

--- a/installer/src/panels/com/izforge/izpack/installer/Unpacker.java
+++ b/installer/src/panels/com/izforge/izpack/installer/Unpacker.java
@@ -866,7 +866,10 @@ public class Unpacker extends UnpackerBase
 	    	// Standard jar file extraction if an RT server exists.
 	    	if (runtimeEntry != null) {
 			handler.progress(i + 1, "Runtime " + runtimeEntry.getName());
-	    		String[] rtlComponents = rtl[i].split(java.io.File.separator);
+				String separator = java.io.File.separator;
+				if (separator.equals("\\"))
+					separator = "/";
+	    		String[] rtlComponents = rtl[i].split(separator);
 	    		File entryFile = new File(installLocation, rtlComponents[0]);
 	    	    entryFile.setLastModified(runtimeEntry.getTime());
 	            entryFile.getParentFile().mkdirs();

--- a/installer/src/panels/com/jboss/devstudio/core/installer/DiskSpaceCheckPanel.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/DiskSpaceCheckPanel.java
@@ -18,7 +18,6 @@ import com.izforge.izpack.Pack;
 import com.izforge.izpack.installer.InstallData;
 import com.izforge.izpack.installer.InstallerFrame;
 import com.izforge.izpack.installer.IzPanel;
-import com.izforge.izpack.installer.Unpacker;
 import com.izforge.izpack.util.IoHelper;
 
 public class DiskSpaceCheckPanel extends IzPanel
@@ -65,11 +64,12 @@ public class DiskSpaceCheckPanel extends IzPanel
    private static long calculateAggregateSize(String sizes)
    {
       long totalSize = 0;
-      if (sizes != null && !sizes.isEmpty()) {
+
+      if (sizes != null && !sizes.trim().isEmpty() && !sizes.equals("null")) {
     	  String[] afs = sizes.split(",");
-    	  for (int i = 0; i < afs.length; i++) 
+    	  for (int i = 0; i < afs.length; i++)
     		  totalSize += Long.parseLong(afs[i]);
-      }
+	  }
       return totalSize;
    }
     


### PR DESCRIPTION
Avoid backslash separator for WIndows and check for 'null' when calculating agg size.

@dgolovin - could you review/push?  thkx!!