### PR TITLE
JBDS-4152 - disable row selection for non-editable table rows in the …

### DIFF
--- a/installer/src/panels/com/jboss/devstudio/core/installer/P2IUListPanel.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/P2IUListPanel.java
@@ -72,7 +72,7 @@ public class P2IUListPanel extends JPanel {
 		this.langpack = langpack;
 
 		table = new JTable(new P2IUListTableModel());
-
+		table.setRowSelectionAllowed(false);
 		table.getColumnModel().getColumn(1).setPreferredWidth(440);
 		table.getColumnModel().getColumn(1).setMinWidth(440);
 		table.getColumnModel().getColumn(0).setPreferredWidth(110);

--- a/installer/src/panels/com/jboss/devstudio/core/installer/RuntimeServerListPanel.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/RuntimeServerListPanel.java
@@ -64,7 +64,7 @@ public class RuntimeServerListPanel extends JPanel {
 		this.langpack = langpack;
 
 		table = new JTable(new RuntimeServerListTableModel());
-
+		table.setRowSelectionAllowed(false);
 		table.getColumnModel().getColumn(1).setPreferredWidth(440);
 		table.getColumnModel().getColumn(1).setMinWidth(440);
 		table.getColumnModel().getColumn(0).setPreferredWidth(110);


### PR DESCRIPTION
…P2IU list panel and runtime server list panel.  Selecting the row obscures the check-mark in the check box widget.  This change corrects that issue (no highlighting on row selection).  See Jira for details.

https://issues.jboss.org/browse/JBDS-4152

This fix targets Devstudio 10.3.0.AM1.  Try it out here:

http://download.jboss.org/jbosstools/neon/staging/updates/integration-stack/proto/devstudio-is-installer-10.1.1-SNAPSHOT.jar

@alexeykazakov @dgolovin - please consider at your convenience