### PR TITLE
JBIDE-23657 switch from PermSize to...

### DIFF
--- a/plugins/com.jboss.devstudio.core/eclipse.ini
+++ b/plugins/com.jboss.devstudio.core/eclipse.ini
@@ -2,10 +2,8 @@
 plugins/org.eclipse.equinox.launcher_${org.eclipse.equinox.launcher.version}.jar
 --launcher.library
 plugins/org.eclipse.equinox.launcher.gtk.linux.x86_${org.eclipse.equinox.launcher.gtk.linux.x86.version}
---launcher.XXMaxPermSize
-256m
 -vmargs
 -Xms256m
 -Xmx1024m
--XX:MaxPermSize=256m
+-XX:MetaspaceSize=256m
 -Dosgi.bundles=reference:file:org.eclipse.equinox.simpleconfigurator_${org.eclipse.equinox.simpleconfigurator.version}.jar@1:start,org.eclipse.equinox.transforms.xslt@1:start,org.jboss.tools.equinox.transforms.xslt@1:start

--- a/plugins/com.jboss.devstudio.core/launches/devstudio-en_AA.launch
+++ b/plugins/com.jboss.devstudio.core/launches/devstudio-en_AA.launch
@@ -20,7 +20,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl en_AA"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms128m&#13;&#10;-Xmx512m&#13;&#10;-XX:MaxPermSize=128m&#10;-d32"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms128m&#13;&#10;-Xmx512m&#13;&#10;-XX:MetaspaceSize=256m&#10;-d32"/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="com.jboss.devstudio.core.product"/>
 <booleanAttribute key="show_selected_only" value="false"/>

--- a/site/com.jboss.devstudio.core.product
+++ b/site/com.jboss.devstudio.core.product
@@ -25,8 +25,6 @@ Red Hat, Inc. - Initial implementation.
 com.jboss.devstudio.core.product
 -showsplash
 platform\:/base/plugins/com.jboss.devstudio.core
---launcher.XXMaxPermSize
-256m
 --launcher.defaultAction
 openFile</programArgs>
       <vmArgs>-Xms512m
@@ -34,7 +32,7 @@ openFile</programArgs>
 -Dosgi.framework.extensions=org.eclipse.wst.jsdt.nashorn.extension
 -Dosgi.instance.area.default=@user.home/workspace</vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
--Xdock:icon=../Resources/devstudio.icns -XX:MaxPermSize=256m -Xdock:name=&quot;Red Hat JBoss Developer Studio&quot;</vmArgsMac>
+-Xdock:icon=../Resources/devstudio.icns -XX:MetaspaceSize=256m -Xdock:name=&quot;Red Hat JBoss Developer Studio&quot;</vmArgsMac>
    </launcherArgs>
 
    <windowImages/>


### PR DESCRIPTION
JBIDE-23657 switch from PermSize to MetaspaceSize (since we requite JDK8); also bump MaxMetaspaceSize to 512m from 256m

Signed-off-by: nickboldt <nboldt@redhat.com>