### PR TITLE
JBDS-4230 JBDS-4204 add devstudio-wayland...

### DIFF
--- a/installer/src/config/install-pack-installer.xml
+++ b/installer/src/config/install-pack-installer.xml
@@ -16,6 +16,8 @@
 
       <singlefile src="config/resources/devstudio-unity" target="$INSTALL_PATH/devstudio-unity" condition="izpack.linuxinstall" />
       <executable targetfile="$INSTALL_PATH/devstudio-unity" condition="izpack.linuxinstall" />
+      <singlefile src="config/resources/devstudio-wayland" target="$INSTALL_PATH/devstudio-wayland" condition="izpack.linuxinstall" />
+      <executable targetfile="$INSTALL_PATH/devstudio-wayland" condition="izpack.linuxinstall" />
       <singlefile src="config/resources/icons/48-devstudio.icon.png" target="$INSTALL_PATH/studio/48-devstudio.icon.png" condition="izpack.linuxinstall" />
       <singlefile src="config/resources/icons/48-uninstall.icon.png" target="$INSTALL_PATH/studio/48-uninstall.icon.png" condition="izpack.linuxinstall" />
       <singlefile src="config/resources/icons/devstudio.ico" target="$INSTALL_PATH/studio/devstudio.ico" os="windows" />

--- a/installer/src/config/resources/devstudio-wayland
+++ b/installer/src/config/resources/devstudio-wayland
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Copyright (c) 2016-2017 Red Hat, Inc.
+# Distributed under license by Red Hat, Inc. All rights reserved.
+# This program is made available under the terms of the
+# Eclipse Public License v1.0 which accompanies this distribution,
+# and is available at http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Red Hat, Inc. - initial API and implementation
+#
+# 
+# This script is provided to disble Wayland and use X11 instead
+# It is workaround for https://issues.jboss.org/browse/JBDS-4230
+# and https://issues.jboss.org/browse/JBDS-4204
+
+GDK_BACKEND=x11 $(dirname "$0")/studio/devstudio

--- a/installer/src/panels/com/jboss/devstudio/core/installer/ShortcutPanelPatch.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/ShortcutPanelPatch.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
 package com.jboss.devstudio.core.installer;
 
 import java.io.BufferedOutputStream;
@@ -43,6 +54,7 @@ public class ShortcutPanelPatch extends IzPanel {
 		"InstallConfigRecord.xml",
 		"devstudio",
 		"devstudio-unity",
+		"devstudio-wayland",
 		"JBoss-EULA.html",
 		"readme.txt"
 	};


### PR DESCRIPTION
JBDS-4230 JBDS-4204 add devstudio-wayland executable to work around wayland/x11 problems in Fedora 25

Signed-off-by: nickboldt <nboldt@redhat.com>