### PR TITLE
JBDS-4257 com.google.guava 0.15 no longer...

### DIFF
--- a/rpm/devstudio.blacklist.txt
+++ b/rpm/devstudio.blacklist.txt
@@ -162,9 +162,7 @@ org.eclipse.m2e.profiles.ui
 org.eclipse.m2e.refactoring
 org.eclipse.m2e.scm
 org.eclipse.m2e.workspace.cli
-
-# JBDS-4131 keep com.google.guava 0.15 because o.e.m2e needs it
-# com.google.guava
+com.google.guava
 
 # JBDS-4134 remove stuff available from rh-eclipse46-eclipse-cdt-native
 org.eclipse.cdt.core.native


### PR DESCRIPTION
JBDS-4257 com.google.guava 0.15 no longer needed as 0.18 is provided by m2e rpm bundle; rh-eclipse46/root/usr/share/eclipse/droplets/m2e-core/eclipse/plugins/com.google.guava_18.0.0.jar -> ../../../../../java/guava.jar

Signed-off-by: nickboldt <nboldt@redhat.com>