### PR TITLE
JBTIS-870 - add JBoss SOA Development to the installer update packs p…

### DIFF
--- a/installer/src/panels/com/jboss/devstudio/core/installer/UpdatePacksPanel.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/UpdatePacksPanel.java
@@ -45,6 +45,8 @@ public class UpdatePacksPanel extends IzPanel{
 				additionalSummaryInfo = additionalSummaryInfo.concat("Red Hat JBoss Business Process and Rules Development<br>");
 			if (installIUs.contains("integration-stack.ds"))
 				additionalSummaryInfo = additionalSummaryInfo.concat("Red Hat JBoss Data Virtualization<br>");
+			if (installIUs.contains("integration-stack.soa"))
+				additionalSummaryInfo = additionalSummaryInfo.concat("Red Hat JBoss Integration and SOA Development<br>");
 		}
 
 		String installRTLocs = idata.getVariable("INSTALL_RT_LOCATIONS");


### PR DESCRIPTION
…anel - Trivial change - add JBoss SOA Development to the install summary page.

![install-soa2](https://cloud.githubusercontent.com/assets/2981421/22480585/e6593154-e7bf-11e6-9e0b-4e344a8d8719.png)

@dgolovin @jeffmaury - please consider and push at your convenience