### PR TITLE
JBIDE-23963 use new version of Central:...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <tpc.version>${TARGET_PLATFORM_VERSION_MAX}</tpc.version>
     <tycho.scmUrl>scm:git:https://github.com/jbdevstudio/jbdevstudio-product.git</tycho.scmUrl>
     <!-- JBDS-2805 used in results/pom.xml to provide link to Central zip -->
-    <central.tpc.version>4.62.0.Final-SNAPSHOT</central.tpc.version>
+    <central.tpc.version>4.63.0.Final-SNAPSHOT</central.tpc.version>
     <JBOSS_CENTRAL_ZIP>https://devstudio.redhat.com/${devstudioReleaseVersion}/snapshots/builds/jbosstools-build-sites.aggregate.central-site_${stream_jbt}/latest/all/repository.zip</JBOSS_CENTRAL_ZIP>
 
     <!-- stream_jbt is set in parent pom = 4.4.neon / master -->


### PR DESCRIPTION
JBIDE-23963 use new version of Central: 4.63.0.Final-SNAPSHOT

Signed-off-by: nickboldt <nboldt@redhat.com>