### PR TITLE
JBDS-4417 make...

### DIFF
--- a/features/com.jboss.devstudio.core.rpm.feature/feature.xml
+++ b/features/com.jboss.devstudio.core.rpm.feature/feature.xml
@@ -89,6 +89,7 @@
     <import feature="org.sonatype.m2e.buildhelper.feature"/>
     <import feature="org.sonatype.m2e.egit.feature"/>
     <import feature="org.sonatype.m2e.mavenarchiver.feature"/>
+    <import plugin="org.eclipse.wst.jsdt.nashorn.extension"/>
     <!-- 
        The following plugins are required for completeness and usability of product only. 
        We have no compilation requirements against them, nor any critical outstanding bugs


### PR DESCRIPTION
JBDS-4417 make com.jboss.devstudio.core.rpm.feature depend on org.eclipse.wst.jsdt.nashorn.extension so we can use it on startup as -Dosgi.framework.extensions=org.eclipse.wst.jsdt.nashorn.extension

Signed-off-by: nickboldt <nboldt@redhat.com>