### PR TITLE
JBDS-4417: Removing '-Dosgi.framework.extensions=org.eclipse.wst.jsdt…

### DIFF
--- a/rpm/eclipse.ini.devstudio
+++ b/rpm/eclipse.ini.devstudio
@@ -25,5 +25,4 @@ openFile
 -Dp2.fragments=/opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets,/opt/rh/rh-eclipse46/root/usr/lib64/eclipse/droplets
 -Declipse.p2.skipMovedInstallDetection=true
 -Dosgi.bundles=org.eclipse.equinox.simpleconfigurator@1:start,org.eclipse.equinox.transforms.xslt@1:start,org.jboss.tools.equinox.transforms.xslt@1:start
--Dosgi.framework.extensions=org.eclipse.wst.jsdt.nashorn.extension
 -Dosgi.instance.area.default=@user.home/workspace


### PR DESCRIPTION
….nashorn.extension' from eclipse.ini.devstudio

Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>