### PR TITLE
JBDS-4417 remove...

### DIFF
--- a/rpm/eclipse.ini.devstudio
+++ b/rpm/eclipse.ini.devstudio
@@ -25,5 +25,4 @@ openFile
 -Dp2.fragments=/opt/rh/rh-eclipse46/root/usr/share/eclipse/droplets,/opt/rh/rh-eclipse46/root/usr/lib64/eclipse/droplets
 -Declipse.p2.skipMovedInstallDetection=true
 -Dosgi.bundles=org.eclipse.equinox.simpleconfigurator@1:start,org.eclipse.equinox.transforms.xslt@1:start,org.jboss.tools.equinox.transforms.xslt@1:start
--Dosgi.framework.extensions=org.eclipse.wst.jsdt.nashorn.extension
 -Dosgi.instance.area.default=@user.home/workspace

--- a/site/com.jboss.devstudio.core.product
+++ b/site/com.jboss.devstudio.core.product
@@ -29,7 +29,6 @@ platform\:/base/plugins/com.jboss.devstudio.core
 openFile</programArgs>
       <vmArgs>-Xms512m
 -Xmx1024m
--Dosgi.framework.extensions=org.eclipse.wst.jsdt.nashorn.extension
 -Dosgi.instance.area.default=@user.home/workspace</vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
 -Xdock:icon=../Resources/devstudio.icns -XX:MetaspaceSize=256m -Xdock:name=&quot;Red Hat JBoss Developer Studio&quot;</vmArgsMac>


### PR DESCRIPTION
JBDS-4417 remove -Dosgi.framework.extensions=org.eclipse.wst.jsdt.nashorn.extension from site/com.jboss.devstudio.core.product and rpm/eclipse.ini.devstudio

Signed-off-by: nickboldt <nboldt@redhat.com>