### PR TITLE
JBIDE-24245 add Fuse Tools features to...

### DIFF
--- a/features/com.jboss.devstudio.fuse.feature/build.properties
+++ b/features/com.jboss.devstudio.fuse.feature/build.properties
@@ -1,0 +1,5 @@
+bin.includes = feature.xml,\
+               feature.properties
+src.includes = feature.xml,\
+               feature.properties,\
+               build.properties

--- a/features/com.jboss.devstudio.fuse.feature/feature.properties
+++ b/features/com.jboss.devstudio.fuse.feature/feature.properties
@@ -1,0 +1,36 @@
+###############################################################################
+# Copyright (c) 2017 Red Hat, Inc. and others.
+# All rights reserved. This program and the accompanying materials 
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+# 
+# Contributors:
+# Red Hat, Inc. - Initial implementation.
+##############################################################################
+# feature.properties
+# contains externalized strings for feature.xml
+# "%foo" in feature.xml corresponds to the key "foo" in this file
+# java.io.Properties file (ISO 8859-1 with "\" escapes)
+# This file should be translated.
+
+# "featureName" property - name of the feature
+featureName=Red Hat JBoss Fuse Tools
+
+# "providerName" property - name of the company that provides the feature
+providerName=JBoss by Red Hat
+
+# "description" property - description of the feature
+description=This feature contains all the features of JBoss Fuse Tools.
+
+# "copyright" property - text of the "Feature Update Copyright"
+copyright=Copyright (c) 2017 Red Hat, Inc. and others.\nAll rights reserved. This program and the accompanying materials\n 
+are made available under the terms of the Eclipse Public License v1.0\n\
+which accompanies this distribution, and is available at\n\
+http\://www.eclipse.org/legal/epl-v10.html\n\
+\n\
+Contributors\:\n\
+Red Hat, Inc. - Initial implementation.\n
+ ############### end of copyright property ####################################
+
+licenseURL=license.html

--- a/features/com.jboss.devstudio.fuse.feature/feature.xml
+++ b/features/com.jboss.devstudio.fuse.feature/feature.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature 
+    id="com.jboss.devstudio.fuse.feature" 
+    label="%featureName" 
+    version="11.0.0.qualifier" 
+    provider-name="%providerName" 
+    license-feature="org.jboss.tools.foundation.license.feature"
+    license-feature-version="0.0.0">
+
+  <description url="https://access.redhat.com/documentation/en/red-hat-jboss-developer-studio/">
+    %description
+  </description>
+  
+  <copyright>
+    %copyright
+  </copyright>
+
+  <license url="%licenseURL">
+    %license
+  </license>
+
+   <requires>
+    <import feature="org.fusesource.ide.core.feature"/>
+    <import feature="org.fusesource.ide.camel.editor.feature"/>
+    <import feature="org.fusesource.ide.jmx.feature"/>
+    <import feature="org.fusesource.ide.server.extensions.feature"/>
+    <import feature="org.jboss.tools.fuse.transformation.feature"/>
+  </requires>
+</feature>

--- a/features/com.jboss.devstudio.fuse.feature/pom.xml
+++ b/features/com.jboss.devstudio.fuse.feature/pom.xml
@@ -1,0 +1,13 @@
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.jboss.devstudio.core</groupId>
+		<artifactId>features</artifactId>
+		<version>11.0.0-SNAPSHOT</version>
+	</parent>
+	<groupId>com.jboss.devstudio.core.features</groupId>
+	<artifactId>com.jboss.devstudio.fuse.feature</artifactId>
+	<packaging>eclipse-feature</packaging>
+</project>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -19,6 +19,7 @@
 		<module>com.jboss.devstudio.core.feature.source</module>
 		<module>com.jboss.devstudio.core.capabilities.feature</module>
 		<module>com.jboss.devstudio.core.capabilities.feature.source</module>
+		<module>com.jboss.devstudio.fuse.feature</module>
 	</modules>
 </project>
 	

--- a/installer/category.xml
+++ b/installer/category.xml
@@ -10,4 +10,7 @@
 	<feature id="org.testng.eclipse">
 		<category name="devstudio" />
 	</feature>
+	<feature id="com.jboss.devstudio.fuse.feature">
+		<category name="devstudio" />
+	</feature>
 </site>

--- a/installer/src/config/resources/DevstudioFeaturesSpec.json
+++ b/installer/src/config/resources/DevstudioFeaturesSpec.json
@@ -7,6 +7,13 @@
 		"selected"   :"true"
 	},
 	{
+		"id"         :"com.jboss.devstudio.fuse.feature.feature.group",
+		"path"       :"devstudio",
+		"label"      :"JBoss Fuse Tools",
+		"description":"",
+		"selected"   :"true"
+	},
+	{
 		"id"         :"org.testng.eclipse.feature.group",
 		"path"       :"devstudio",
 		"label"      :"TestNG",

--- a/installer/src/panels/com/izforge/izpack/installer/Unpacker.java
+++ b/installer/src/panels/com/izforge/izpack/installer/Unpacker.java
@@ -680,7 +680,7 @@ public class Unpacker extends UnpackerBase
 
 	public static String resolveIUs(String ius) {
 		if(ius == null || "".equals(ius.trim())) {
-			ius = "com.jboss.devstudio.core.package,org.testng.eclipse.feature.group";
+			ius = "com.jboss.devstudio.core.package,com.jboss.devstudio.fuse.feature.feature.group,org.testng.eclipse.feature.group";
 		}
 		return ius;
 	}

--- a/site/category.xml
+++ b/site/category.xml
@@ -290,6 +290,26 @@
     <category name="CoreTools" />
   </feature>
 
+  <feature id="org.fusesource.ide.core.feature">
+    <category name="FuseTools" />
+  </feature>
+
+  <feature id="org.fusesource.ide.camel.editor.feature">
+    <category name="FuseTools" />
+  </feature>
+
+  <feature id="org.fusesource.ide.jmx.feature">
+    <category name="FuseTools" />
+  </feature>
+
+  <feature id="org.fusesource.ide.server.extensions.feature">
+    <category name="FuseTools" />
+  </feature>
+
+  <feature id="org.jboss.tools.fuse.transformation.feature">
+    <category name="FuseTools" />
+  </feature>
+
   <!-- include but do not categorize -->
   <feature id="org.jboss.tools.central.feature"/>
   <feature id="org.jboss.tools.common.feature"/>
@@ -363,6 +383,11 @@
   <feature id="com.jboss.devstudio.core.capabilities.feature"/>
   <feature id="com.jboss.devstudio.core.rpm.feature"/>
   <feature id="com.jboss.devstudio.core.rpmdeps.feature"/>
+  <feature id="com.jboss.devstudio.fuse.feature">
+    <category name="BringYourOwnEclipse" />
+    <category name="CoreTools" />
+    <category name="FuseTools" />
+  </feature>
   <feature id="org.eclipse.egit"/>
   <feature id="org.eclipse.jgit"/>
   <feature id="org.eclipse.m2e.feature"/>
@@ -444,6 +469,12 @@
   <bundle id="org.jboss.tools.discovery.core.source"/>
   <!-- not in devstudio yet? <bundle id="org.jboss.tools.foundation.help.ui.source"/> -->
 
+  <feature id="org.fusesource.ide.core.feature.source"/>
+  <feature id="org.fusesource.ide.camel.editor.feature.source"/>
+  <feature id="org.fusesource.ide.jmx.feature.source"/>
+  <feature id="org.fusesource.ide.server.extensions.feature.source"/>
+  <feature id="org.jboss.tools.fuse.transformation.feature.source"/>
+
   <!-- only in JBT
   <feature id="org.jboss.tools.arquillian.feature.source"/>
   <feature id="org.jboss.tools.central.themes.feature.source"/>
@@ -504,4 +535,9 @@
   <category-def name="CloudContainerTools" label="JBoss Cloud And Container Development Tools">
     <description>Tools for Cloud and Container Development.</description>
   </category-def>
+
+  <category-def name="FuseTools" label="JBoss Fuse Tools">
+    <description>Tools to allow you to create Apache Camel routes in a graphical editor, launch them locally and deploy them to runtimes like Apache Karaf, Fabric8 and JBoss Fuse.</description>
+  </category-def>
+
 </site>


### PR DESCRIPTION
JBIDE-24245 add Fuse Tools features to devstudio site; create wrapper feature com.jboss.devstudio.fuse.feature to provide all-in-one fuse install option; add fuse.feature to DevstudioFeaturesSpec.json and into installer

Signed-off-by: nickboldt <nboldt@redhat.com>