### PR TITLE
JBDS-4447 correct name for JBoss Fuse Tooling (not Tools)

### DIFF
--- a/installer/src/config/resources/AdditionalFeaturesSpec.json
+++ b/installer/src/config/resources/AdditionalFeaturesSpec.json
@@ -2,7 +2,7 @@
 	{
 		"id"         :"com.jboss.devstudio.fuse.feature.feature.group",
 		"path"       :"devstudio",
-		"label"      :"JBoss Fuse Tools",
+		"label"      :"JBoss Fuse Tooling",
 		"description":"",
 		"selected"   :"false"
 	}


### PR DESCRIPTION
Based on comment at [1] I propose to change Fuse label to "JBoss Fuse Tooling".

[1] https://github.com/jbdevstudio/jbdevstudio-product/commit/81982a8c27dfa08c73a51edce97d9b130f4bdd0e