### PR TITLE
JBDS-4538 depend on docker tooling rpm;...

### DIFF
--- a/features/com.jboss.devstudio.core.rpmdeps.feature/feature.xml
+++ b/features/com.jboss.devstudio.core.rpmdeps.feature/feature.xml
@@ -50,6 +50,7 @@
     <import feature="org.eclipse.jst.ws.cxf.feature"/>
     <import feature="org.eclipse.jst.ws.jaxws.dom.feature"/>
     <import feature="org.eclipse.jst.ws.jaxws.feature"/>
+    <import feature="org.eclipse.linuxtools.docker.feature"/>
     <import feature="org.eclipse.m2e.feature"/>
     <import feature="org.eclipse.mylyn.wikitext_feature"/>
     <import feature="org.eclipse.platform"/>
@@ -77,9 +78,6 @@
     <import plugin="org.eclipse.jem.util" />
     <import plugin="org.eclipse.jst.server.tomcat.core"/>
     <import plugin="org.eclipse.jst.server.tomcat.ui"/>
-    <import plugin="org.eclipse.linuxtools.docker.core" version="1.1.0" match="greaterOrEqual"/>
-    <import plugin="org.eclipse.linuxtools.docker.docs" version="1.1.0" match="greaterOrEqual"/>
-    <import plugin="org.eclipse.linuxtools.docker.ui" version="1.1.0" match="greaterOrEqual"/>
     <import plugin="org.eclipse.rse.connectorservice.local"/>
     <import plugin="org.eclipse.rse.connectorservice.ssh"/>
     <import plugin="org.eclipse.rse.core" version="3.3.100" match="greaterOrEqual" />

--- a/rpm/devstudio.blacklist.txt
+++ b/rpm/devstudio.blacklist.txt
@@ -225,9 +225,11 @@ org.eclipse.pde.genericeditor
 org.eclipse.pde.genericeditor.extension
 
 # JBDS-4498 add these back in
-# net.sourceforge.lpg.lpgjavaruntime
 # org.apache.commons.lang
 # org.apache.lucene.core
 # org.glassfish.hk2.osgi-resource-locator
 # org.glassfish.jersey.bundles.repackaged.jersey-guava
 # org.glassfish.jersey.core.jersey-common
+
+# remove - provided by rh-eclipse47-eclipse-cdt-parsers
+net.sourceforge.lpg.lpgjavaruntime

--- a/rpm/devstudio.blacklist.txt
+++ b/rpm/devstudio.blacklist.txt
@@ -24,6 +24,14 @@ javax.servlet.jsp
 javax.ws.rs
 javax.ws.rs-api
 
+# docker feature/plugins
+org.eclipse.linuxtools.docker.core
+org.eclipse.linuxtools.docker.docs
+org.eclipse.linuxtools.docker.editor
+org.eclipse.linuxtools.docker.feature
+org.eclipse.linuxtools.docker.ui
+org.eclipse.linuxtools.jdt.docker.launcher
+
 #➔ find . -name org.eclipse.osgi_\*
 # ./usr/lib64/eclipse/plugins/org.eclipse.osgi_3.11.0.v20160819-1000.jar
 org.eclipse.osgi

--- a/rpm/devstudio.removelist.txt
+++ b/rpm/devstudio.removelist.txt
@@ -30,6 +30,7 @@ jnr.ffi
 jnr.posix
 jnr.unixsocket
 jnr.x86asm
+net.sourceforge.lpg.lpgjavaruntime
 org.apache.ant
 org.apache.axis
 org.apache.batik.css
@@ -349,6 +350,7 @@ org.eclipse.linuxtools.docker.docs
 org.eclipse.linuxtools.docker.editor
 org.eclipse.linuxtools.docker.feature
 org.eclipse.linuxtools.docker.ui
+org.eclipse.linuxtools.jdt.docker.launcher
 org.eclipse.ltk.core.refactoring
 org.eclipse.ltk.ui.refactoring
 org.eclipse.m2e.archetype.common

--- a/rpm/devstudio.spec.template
+++ b/rpm/devstudio.spec.template
@@ -44,6 +44,9 @@ Requires: rh-eclipse47-eclipse-rse
 # tm deps: org.eclipse.tm.terminal.connector.local
 Requires: rh-eclipse47-eclipse-tm-terminal-connectors
 
+# JBDS-4538 docker tooling dep:
+Requires: rh-eclipse47-eclipse-linuxtools-docker
+
 # include AERI logging/reporting
 Requires: rh-eclipse47-eclipse-epp-logging
 
@@ -143,6 +146,9 @@ echo "org.slf4j.api,1.7.4,plugins/org.slf4j.api_1.7.4.jar,4,false" >> %{buildroo
 # %{buildroot}/usr/lib64/eclipse/eclipse.ini
 
 %changelog
+* Mon Sep 04 2017 Nick Boldt <nboldt@redhat.com> 11.1.0.20170904-1119
+- JBDS-4538 depend on docker tooling rpm
+
 * Thu Aug 10 2017 Nick Boldt <nboldt@redhat.com> 11.1.0.20170810-1744
 - Bump to 11.1.0
 

--- a/rpm/devstudio.spec.template
+++ b/rpm/devstudio.spec.template
@@ -34,6 +34,8 @@ Requires: libIDL
 Requires: rh-eclipse47-eclipse-cdt-native
 # include freemarker because cdt's org.eclipse.tools.templates.freemarker needs it 
 Requires: rh-eclipse47-freemarker
+# rh-eclipse47-eclipse-cdt-parsers provides net.sourceforge.lpg.lpgjavaruntime
+Requires: rh-eclipse47-eclipse-cdt-parsers
 
 # m2e deps
 Requires: rh-eclipse47-eclipse-m2e-core, rh-eclipse47-eclipse-m2e-workspace


### PR DESCRIPTION
JBDS-4538 depend on docker tooling rpm; include docker tooling FEATURE instead of plugins, so that we can also exclude org.eclipse.linuxtools.jdt.docker.launcher

Signed-off-by: nickboldt <nboldt@redhat.com>