### PR TITLE
JBDS-4593 Enable devstudio launch with java 9

### DIFF
--- a/site/com.jboss.devstudio.core.product
+++ b/site/com.jboss.devstudio.core.product
@@ -29,6 +29,7 @@ platform\:/base/plugins/com.jboss.devstudio.core
 openFile</programArgs>
       <vmArgs>-Xms512m
 -Xmx1024m
+--add-modules=ALL-SYSTEM
 -Dosgi.instance.area.default=@user.home/workspace</vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
 -Xdock:icon=../Resources/devstudio.icns -XX:MetaspaceSize=256m -Xdock:name=&quot;Red Hat JBoss Developer Studio&quot;</vmArgsMac>


### PR DESCRIPTION
This is exactly the same change that Oxygen 1a has
in their eclipse.ini. It works for both java 8 and 9.