### PR TITLE
JBDS-4588 fix problem parsing versions '9-ea'

### DIFF
--- a/installer/src/panels/com/jboss/devstudio/core/installer/JREPathPanel.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/JREPathPanel.java
@@ -358,7 +358,7 @@ public class JREPathPanel extends PathInputPanel implements IChangeListener {
 		}
 		int versionNumber = 0;
 
-		String[] detectedVersionBits = detectedVersion.split("\\.");
+		String[] detectedVersionBits = detectedVersion.split("\\.|-|_");
 		if (detectedVersionBits.length > 0) 
 		{
 			if (detectedVersionBits[0].equals("1")) {


### PR DESCRIPTION
JBDS-4588 fix problem parsing versions '9-ea'

Signed-off-by: Lukáš Valach <lvalach@redhat.com>