### PR TITLE
Fix names for projects in plugins and features folders

### DIFF
--- a/features/.project
+++ b/features/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>features</name>
+	<name>com.jboss.devstudio.features</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/plugins/.project
+++ b/plugins/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>plugins</name>
+	<name>com.jboss.devstudio.plugins</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
This fix sets unique names for product/{plugins,features}.project files to avoid conflicts when importing other projects form jbosstools repositories.

Signed-off-by: Denis Golovin <dgolovin@gmail.com>

