### PR TITLE
JBDS-4744 Add back dependency for com.sun.tools to fix failing ant build

### DIFF
--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -265,13 +265,13 @@
 							<artifactId>ant-contrib</artifactId>
 							<version>1.0b3</version>
 						</dependency>
-						<!-- JBDS-4742 remove <dependency>
+						<dependency>
 							<groupId>com.sun</groupId>
 							<artifactId>tools</artifactId>
-							<version>1.5.0</version>
+							<version>1.8.0</version>
 							<scope>system</scope>
 							<systemPath>${java.home}/../lib/tools.jar</systemPath>
-						</dependency> -->
+						</dependency>
 					</dependencies>
 				</plugin>
 			<plugin>


### PR DESCRIPTION
of devstudio

Signed-off-by: Josef Kopriva <jkopriva@redhat.com>